### PR TITLE
Dodanie dyrektywy :linenos: do większych bloków code-block

### DIFF
--- a/best_practices/security.rst
+++ b/best_practices/security.rst
@@ -10,7 +10,7 @@ Uwierzytelnianie i zapory (czyli uzyskiwanie poświadczeń użytkownika)
 
 Można skonfigurować Symfony do uwierzytelniania użytkowników różnymi metodami
 oraz ładowania informacji o użytkownikach z różnych źródeł. Jest to skomplikowany
-temat, ale :doc:`rozdział "Bezpieczeństwo" receptariusza </cookbook/security/index>`
+temat, ale rozdział :doc:`"Bezpieczeństwo"</cookbook/security/index>` w Receptariuszu
 ma wiele informacji z tego zakresu.
 
 Uwierzytelnianie jest skonfigurowane w pliku ``security.yml``,
@@ -19,17 +19,17 @@ przede wszystkim w kluczu ``firewalls``.
 .. best-practice::
 
     Dopóki nie ma się dwóch różnych systemów uwierzytelniania i dwóch różnych
-    zestawów użytkowników (np. logowanie formularzowe na stronie głownej a
-    system tkenowy tylko dla swojego API), zaleca się posiadanie tylko *jedną*
-    skonfigurowaną zaporę z włączonym kluczem ``anonymous``.
+    zestawów użytkowników (np. logowanie formularzowe na stronie głównej a
+    system tokenowy tylko dla swojego API), zaleca się posiadanie tylko *jednej*
+    skonfigurowanej zapory z włączonym kluczem ``anonymous``.
 
 Większość aplikacji ma tylko jeden system uwierzytelniania i tylko jeden zestaw
 użytkowników.
 Dlatego też wystarczy mieć tylko *jedną* skonfigurowaną zaporę. Oczywiście są
-wyjątki, zwłaszcza jeśli ma się odzielne sekcje web i API na swojej witrynie.
+wyjątki, zwłaszcza jeśli ma się oddzielne sekcje web i API na swojej witrynie.
 Jednak chodzi o to, aby zbyt nie komplikować sobie życia.
 
-Dodatkowo, należy w ramach zapory użyć klucza ``anonymous``. Jeśli jest potrzeba,
+Dodatkowo, należy w ramach zapory użyć klucza ``anonymous``. Jeśli jest potrzeba
 wymagania od użytkowników logowania się w różnych sekcjach witryny (albo prawie
 we *wszystkich* sekcjach), trzeba skonfigurować klucz ``access_control``.
 
@@ -39,13 +39,14 @@ we *wszystkich* sekcjach), trzeba skonfigurować klucz ``access_control``.
 
 Zalecamy kodowanie haseł użytkownika przy użyciu kodera ``bcrypt``,
 zamiast tradycyjnego kodera mieszającego SHA-512. Główne zalety ``bcrypt``, to
-włączenie wartości *soli* w celu ochrony wachlarzem ataków tabelowych i jego adaptacyjny
-charakter, czyniący go odporniejszym na ataki siłowego wyszukiwania hasła.
+włączenie wartości *soli* w celu ochrony przed wachlarzem ataków tabelowych i jego
+adaptacyjny charakter, czyniący go odporniejszym na ataki siłowego wyszukiwania hasła.
 
 Mając to na uwadze, prezentujemy poniżej konfigurację uwierzytelniania dla aplikacji,
 która wykorzystuje logowanie formularzowe do załadowania użytkowników z bazy danych:
 
 .. code-block:: yaml
+   :linenos:
 
     # app/config/security.yml
     security:
@@ -110,13 +111,14 @@ Adnotacja @Security
 -------------------
 
 Do kontroli dostępu na bazie akcji kontrolera, użyj w miarę możliwości adnotacji
-``@Security``. Jest ona łatwa do odczytania i umieszczana konsekwntnie nad
+``@Security``. Jest ona łatwa do odczytania i umieszczana konsekwentnie nad
 zabezpieczaną akcją.
 
 W naszej aplikacji, do tworzenia nowych wpisów potrzebna jest rola ``ROLE_ADMIN``.
 Zastosowania ``@Security``, wygląda tak:
 
 .. code-block:: php
+   :linenos:
 
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -137,11 +139,12 @@ Wykorzystywanie wyrażeń dla złożonych ograniczeń dostępu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Jeśli logika zabeczeń jest trochę bardziej złożona, można użyć `wyrażenia`_
-wewnatrz adnotacji ``@Security``. W poniższym przykładzie, użytkownik może tylko
+wewnątrz adnotacji ``@Security``. W poniższym przykładzie, użytkownik może tylko
 mieć dostęp do kontrolera, jeśli adres email jest zgodny z wartością zwracana przez
 metodę ``getAuthorEmail`` na obiekcie ``Post``:
 
 .. code-block:: php
+   :linenos:
 
     use AppBundle\Entity\Post;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -166,15 +169,17 @@ który ma być tylko widoczny dla autorów. Niestety, teraz trzeba powtórzyć t
 kod wyrażenia, stosując składnię Twig:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {% if app.user and app.user.email == post.authorEmail %}
         <a href=""> ... </a>
     {% endif %}
 
-Najprostrzym roziązaniem jest, jeśli logika jest dość prosta, dodanie nowej metody
+Najprostrzym rozwiązaniem jest, jeśli logika jest dość prosta, dodanie nowej metody
 do encji ``Post``, która sprawdza czy dany użytkownik jest autorem:
 
 .. code-block:: php
+   :linenos:
 
     // src/AppBundle/Entity/Post.php
     // ...
@@ -194,10 +199,11 @@ do encji ``Post``, która sprawdza czy dany użytkownik jest autorem:
         }
     }
 
-Teraz można wykorzystać wielokrotnie ta metodę, zarówno w szablonie, jak i wyrażeniu
+Teraz można wykorzystać wielokrotnie tą metodę, zarówno w szablonie, jak i w wyrażeniu
 zabezpieczającym:
 
 .. code-block:: php
+   :linenos:
 
     use AppBundle\Entity\Post;
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -212,6 +218,7 @@ zabezpieczającym:
     }
 
 .. code-block:: html+jinja
+   :linenos:
 
     {% if post.isAuthor(app.user) %}
         <a href=""> ... </a>
@@ -228,7 +235,7 @@ zabezpieczającym:
 Sprawdzanie uprawnień bez adnotacji @Security
 ---------------------------------------------
 
-Powyższy przyklad z wykorzystaniem adnotacji ``@Security`` dziala tylko dlatego,
+Powyższy przykład z wykorzystaniem adnotacji ``@Security`` dziala tylko dlatego,
 że użyliśmy :ref:`ParamConverter <best-practices-paramconverter>`, który podaje
 wyrażenie z regułą dostępu do zmiennej ``post``. Jeśli nie chcesz z tego korzystać,
 lub masz bardziej zaawansowany przypadek, możesz zawsze wykonać indywidualny kod
@@ -334,7 +341,7 @@ Do włączenia wyborcy w aplikacji, trzeba zdefiniować nową usługę:
             tags:
                - { name: security.voter }
 
-Teraz, mozna wykorzystywać wyborcę w adnotacji ``@Security``:
+Teraz, można wykorzystywać wyborcę w adnotacji ``@Security``:
 
 .. code-block:: php
 
@@ -347,7 +354,7 @@ Teraz, mozna wykorzystywać wyborcę w adnotacji ``@Security``:
         // ...
     }
 
-Mozna to również użyć bezpośrednio w usłudze ``security.authorization_checker``
+Można to również użyć bezpośrednio w usłudze ``security.authorization_checker``
 lub przez jeszcze łatwiejszy skrót w akcji kontrolera:
 
 .. code-block:: php

--- a/book/configuration.rst
+++ b/book/configuration.rst
@@ -13,6 +13,7 @@ znajduje się domyślnie w katalogu ``app/config/`` i nosi nazwę ``config.yml``
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         imports:
@@ -32,6 +33,7 @@ znajduje się domyślnie w katalogu ``app/config/`` i nosi nazwę ``config.yml``
         # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -63,6 +65,7 @@ znajduje się domyślnie w katalogu ``app/config/`` i nosi nazwę ``config.yml``
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $this->import('parameters.yml');
@@ -221,6 +224,7 @@ Przyjrzyjmy się plikowi konfiguracyjnemu dla środowiska ``dev``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config_dev.yml
         imports:
@@ -233,6 +237,7 @@ Przyjrzyjmy się plikowi konfiguracyjnemu dla środowiska ``dev``:
         # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config_dev.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -257,6 +262,7 @@ Przyjrzyjmy się plikowi konfiguracyjnemu dla środowiska ``dev``:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config_dev.php
         $loader->import('config.php');

--- a/book/controller.rst
+++ b/book/controller.rst
@@ -104,6 +104,7 @@ Prosty kontroler
 Przeanalizujmy bardzo prosty kod kotrolera: 
 
 .. code-block:: php
+   :linenos:
 
     // src/AppBundle/Controller/HelloController.php
     namespace AppBundle\Controller;
@@ -120,12 +121,11 @@ Przeanalizujmy bardzo prosty kod kotrolera:
     
 .. tip::
 
-    Trzeba mieć na uwadze, że istnieje pewna rozbieżność w stosowaniu nazwy
-    *kontroler*. W angielskojęzycznej dokumentacjj Symfony często słowem *controller*
-    nazywa sie to, co jest metodą (np. ``indexAction``) *klasy kontrolera*
-    (``HelloController``), choć sygnatury klasy i metody sugerują coś innego:
-    metoda, to "akcja" a klasa to "kontroler".
-    W praktyce i lteraturze OOP zwykło się właśnie używać słowa *akcja* na
+    Trzeba mieć na uwadze, że w angielskojęzycznej dokumentacjj Symfony istnieje
+    pewna rozbieżność w stosowaniu nazwy *kontroler* i raz słowem *controller*
+    nazywa sie to, co jest metodą (np. ``indexAction``) klasy kontrolera
+    a innym razem *klasę kontrolera* (np. ``HelloController``).
+    W praktyce i lteraturze OOP zwykło się używać słowa *akcja* na
     metodę klasy kontrolera, a samą klasę *kontrolerem*. Tak więc czytając tą
     dokumentację proszę zwracać uwagę na kontekst słowa "kontroler".    
 
@@ -160,6 +160,7 @@ trzeba utworzyć trasę (*ang. route*) odwzorowującą wzorzec ścieżki URL na 
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/HelloController.php
         namespace AppBundle\Controller;
@@ -179,6 +180,7 @@ trzeba utworzyć trasę (*ang. route*) odwzorowującą wzorzec ścieżki URL na 
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         hello:
@@ -187,6 +189,7 @@ trzeba utworzyć trasę (*ang. route*) odwzorowującą wzorzec ścieżki URL na 
             defaults:  { _controller: AppBundle:Hello:index }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -202,6 +205,7 @@ trzeba utworzyć trasę (*ang. route*) odwzorowującą wzorzec ścieżki URL na 
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\Route;
@@ -271,6 +275,7 @@ Rozpatrzmy bardziej interesujacy przyklad:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/HelloController.php
         // ...
@@ -289,6 +294,7 @@ Rozpatrzmy bardziej interesujacy przyklad:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         hello:
@@ -296,6 +302,7 @@ Rozpatrzmy bardziej interesujacy przyklad:
             defaults:  { _controller: AppBundle:Hello:index }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -310,6 +317,7 @@ Rozpatrzmy bardziej interesujacy przyklad:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\Route;
@@ -687,6 +695,7 @@ komunikatu ``notice``:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {% for flashMessage in app.session.flashbag.get('notice') %}
             <div class="flash-notice">
@@ -695,6 +704,7 @@ komunikatu ``notice``:
         {% endfor %}
 
     .. code-block:: html+php
+       :linenos:
 
         <?php foreach ($view['session']->getFlash('notice') as $message): ?>
             <div class="flash-notice">

--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -64,6 +64,7 @@ bazą danych. Zgodnie z konwencją informacja ta zapisywana jest w pliku
     .. configuration-block::
 
         .. code-block:: yaml
+           :linenos:
 
             # app/config/config.yml
             doctrine:
@@ -75,6 +76,7 @@ bazą danych. Zgodnie z konwencją informacja ta zapisywana jest w pliku
                     password: "%database_password%"
 
         .. code-block:: xml
+           :linenos:
 
             <!-- app/config/config.xml -->
             <?xml version="1.0" encoding="UTF-8" ?>
@@ -97,6 +99,7 @@ bazą danych. Zgodnie z konwencją informacja ta zapisywana jest w pliku
             </container>
 
         .. code-block:: php
+           :linenos:
 
             // app/config/config.php
             $configuration->loadFromExtension('doctrine', array(
@@ -132,7 +135,7 @@ do utworzenia bazy danych:
     poleceń w czasie programowania:
 
     .. code-block:: bash
-
+       
         $ php app/console doctrine:database:drop --force
         $ php app/console doctrine:database:create
 
@@ -144,7 +147,7 @@ do utworzenia bazy danych:
     do pliku konfiguracyjnego serwera (przeważnie ``my.cnf``):
 
     .. code-block:: ini
-
+       
         [mysqld]
         # W versji 5.5.3 wprowadzono zestawa "utf8mb4", który jest zalecany
         collation-server     = utf8mb4_general_ci # Replaces utf8_general_ci
@@ -162,6 +165,7 @@ do utworzenia bazy danych:
     .. configuration-block::
 
         .. code-block:: yaml
+           :linenos:
 
             # app/config/config.yml
             doctrine:
@@ -171,6 +175,7 @@ do utworzenia bazy danych:
                     charset: UTF8
 
         .. code-block:: xml
+           :linenos:
 
             <!-- app/config/config.xml -->
             <?xml version="1.0" encoding="UTF-8" ?>
@@ -191,6 +196,7 @@ do utworzenia bazy danych:
             </container>
 
         .. code-block:: php
+           :linenos:
 
             // app/config/config.php
             $container->loadFromExtension('doctrine', array(
@@ -257,6 +263,7 @@ w klasie ``Product`` poprzez adnotacje:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Product.php
         namespace AppBundle\Entity;
@@ -293,6 +300,7 @@ w klasie ``Product`` poprzez adnotacje:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/doctrine/Product.orm.yml
         AppBundle\Entity\Product:
@@ -313,6 +321,7 @@ w klasie ``Product`` poprzez adnotacje:
                     type: text
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/doctrine/Product.orm.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -816,6 +825,7 @@ Dla wykonania tego, należy dodać nazwę klasy repozytorium do definicji odwzor
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Product.php
         namespace AppBundle\Entity;
@@ -831,6 +841,7 @@ Dla wykonania tego, należy dodać nazwę klasy repozytorium do definicji odwzor
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/doctrine/Product.orm.yml
         AppBundle\Entity\Product:
@@ -839,6 +850,7 @@ Dla wykonania tego, należy dodać nazwę klasy repozytorium do definicji odwzor
             # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/doctrine/Product.orm.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -867,6 +879,7 @@ repozytorium. Metoda ta będzie przepytywać wszystkie encje ``Product`` w kolej
 alfabetycznej.
 
 .. code-block:: php
+   :linenos:
 
     // src/AppBundle/Entity/ProductRepository.php
     namespace AppBundle\Entity;
@@ -932,6 +945,7 @@ właściwości ``products`` w klasie ``Category``:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Category.php
 
@@ -954,6 +968,7 @@ właściwości ``products`` w klasie ``Category``:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/doctrine/Category.orm.yml
         AppBundle\Entity\Category:
@@ -967,6 +982,7 @@ właściwości ``products`` w klasie ``Category``:
             # of the entity
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/doctrine/Category.orm.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1017,6 +1033,7 @@ Następnie, ponieważ każda klasa ``Product`` odnosi się dokładnie do jednego
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Product.php
 
@@ -1033,6 +1050,7 @@ Następnie, ponieważ każda klasa ``Product`` odnosi się dokładnie do jednego
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/doctrine/Product.orm.yml
         AppBundle\Entity\Product:
@@ -1047,6 +1065,7 @@ Następnie, ponieważ każda klasa ``Product`` odnosi się dokładnie do jednego
                         referencedColumnName: id
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/doctrine/Product.orm.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1335,6 +1354,7 @@ kolumnę datową na bieżącą datę, ale tylko wtedy, gdy encja jest pierwszy r
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Product.php
 
@@ -1347,6 +1367,7 @@ kolumnę datową na bieżącą datę, ale tylko wtedy, gdy encja jest pierwszy r
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/doctrine/Product.orm.yml
         AppBundle\Entity\Product:
@@ -1356,6 +1377,7 @@ kolumnę datową na bieżącą datę, ale tylko wtedy, gdy encja jest pierwszy r
                 prePersist: [setCreatedAtValue]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/doctrine/Product.orm.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>

--- a/book/forms.rst
+++ b/book/forms.rst
@@ -147,6 +147,7 @@ formularza:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/default/new.html.twig #}
         {{ form_start(form) }}
@@ -154,6 +155,7 @@ formularza:
         {{ form_end(form) }}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/default/new.html.php -->
         <?php echo $view['form']->start($form) ?>
@@ -343,6 +345,7 @@ być puste i musiało by być prawidłowym obiektem ``DateTime``.
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // AppBundle/Entity/Task.php
         use Symfony\Component\Validator\Constraints as Assert;
@@ -362,6 +365,7 @@ być puste i musiało by być prawidłowym obiektem ``DateTime``.
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # AppBundle/Resources/config/validation.yml
         AppBundle\Entity\Task:
@@ -373,6 +377,7 @@ być puste i musiało by być prawidłowym obiektem ``DateTime``.
                     - Type: \DateTime
 
     .. code-block:: xml
+       :linenos:
 
         <!-- AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -393,6 +398,7 @@ być puste i musiało by być prawidłowym obiektem ``DateTime``.
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // AppBundle/Entity/Task.php
         use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -796,6 +802,7 @@ formularza:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/default/new.html.twig #}
         {{ form_start(form) }}
@@ -806,6 +813,7 @@ formularza:
         {{ form_end(form) }}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/default/newAction.html.php -->
         <?php echo $view['form']->start($form) ?>
@@ -860,6 +868,7 @@ poniższej prezentowanego kodu są takie same, jak dla funkcji ``form_row``:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {{ form_start(form) }}
             {{ form_errors(form) }}
@@ -883,6 +892,7 @@ poniższej prezentowanego kodu są takie same, jak dla funkcji ``form_row``:
         {{ form_end(form) }}
 
     .. code-block:: html+php
+       :linenos:
 
         <?php echo $view['form']->start($form) ?>
 
@@ -1171,6 +1181,7 @@ jest naprawdę łatwa w użyciu.
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/services.yml
         services:
@@ -1180,6 +1191,7 @@ jest naprawdę łatwa w użyciu.
                     - { name: form.type, alias: task }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1195,6 +1207,7 @@ jest naprawdę łatwa w użyciu.
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Resources/config/services.php
         $container
@@ -1390,6 +1403,7 @@ pól ``Task``:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# ... #}
 
@@ -1401,6 +1415,7 @@ pól ``Task``:
         {# ... #}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- ... -->
 
@@ -1460,6 +1475,7 @@ nowy plik szablonowy, który zawierać będzie nowy znacznik:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/form/fields.html.twig #}
         {%- block form_row -%}
@@ -1471,6 +1487,7 @@ nowy plik szablonowy, który zawierać będzie nowy znacznik:
         {% endblock form_row %}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/form/form_row.html.php -->
         <div class="form_row">
@@ -1488,6 +1505,7 @@ części szablonu:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/default/new.html.twig #}
         {% form_theme form 'form/fields.html.twig' %}
@@ -1498,6 +1516,7 @@ części szablonu:
         {# ... render the form #}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/default/new.html.php -->
         <?php $view['form']->setTheme($form, array('form')) ?>
@@ -1629,6 +1648,7 @@ aplikacji:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         twig:
@@ -1637,6 +1657,7 @@ aplikacji:
             # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1653,6 +1674,7 @@ aplikacji:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('twig', array(
@@ -1710,6 +1732,7 @@ plik konfiguracyjny aplikacji:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -1720,6 +1743,7 @@ plik konfiguracyjny aplikacji:
         # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1740,6 +1764,7 @@ plik konfiguracyjny aplikacji:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(

--- a/book/includes/_service_container_my_mailer.rst.inc
+++ b/book/includes/_service_container_my_mailer.rst.inc
@@ -1,6 +1,7 @@
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         services:
@@ -9,6 +10,7 @@
                 arguments:    [sendmail]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -25,6 +27,7 @@
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         use Symfony\Component\DependencyInjection\Definition;

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -265,6 +265,7 @@ Jeśli są jakieś problemy, rozwiąż je teraz, zanim przejdziesz dalej.
     go jako ``HTTPDUSER``:
     
     .. code-block:: bash
+       :linenos:
 
         $ HTTPDUSER=`ps aux | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1`
         $ sudo setfacl -R -m u:"$HTTPDUSER":rwX -m u:`whoami`:rwX app/cache app/logs

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -171,6 +171,7 @@ Poprawmy trasę tak, aby miała na końcu wieloznaczną część ``{wildcard}``:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/LuckyController.php
         // ...
@@ -189,6 +190,7 @@ Poprawmy trasę tak, aby miała na końcu wieloznaczną część ``{wildcard}``:
         }        
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         lucky_number:
@@ -196,6 +198,7 @@ Poprawmy trasę tak, aby miała na końcu wieloznaczną część ``{wildcard}``:
             defaults: { _controller: AppBundle:Lucky:number }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/DemoBundle/Resources/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -210,6 +213,7 @@ Poprawmy trasę tak, aby miała na końcu wieloznaczną część ``{wildcard}``:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/DemoBundle/Resources/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -385,6 +389,7 @@ tam plik ``number.html.twig`` z zawartością:
 .. configuration-block::
 
     .. code-block:: jinja
+       :linenos:
 
         {# app/Resources/views/lucky/number.html.twig #}
         {% extends 'base.html.twig' %}
@@ -394,6 +399,7 @@ tam plik ``number.html.twig`` z zawartością:
         {% endblock %}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/lucky/number.html.php -->
         <?php $view->extend('base.html.php') ?>
@@ -484,6 +490,7 @@ konfiguracyjnym pakietów jest ``app/config/config.yml``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         # ...
@@ -501,6 +508,7 @@ konfiguracyjnym pakietów jest ``app/config/config.yml``:
         # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -529,6 +537,7 @@ konfiguracyjnym pakietów jest ``app/config/config.yml``:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         // ...

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -40,6 +40,7 @@ jest prosta:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/BlogController.php
         namespace AppBundle\Controller;
@@ -59,6 +60,7 @@ jest prosta:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         blog_show:
@@ -66,6 +68,7 @@ jest prosta:
             defaults:  { _controller: AppBundle:Blog:show }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -80,6 +83,7 @@ jest prosta:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -210,6 +214,7 @@ oraz z tablicy ``defaults`` przechowującej wartości domyślne:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/MainController.php
 
@@ -226,6 +231,7 @@ oraz z tablicy ``defaults`` przechowującej wartości domyślne:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         _welcome:
@@ -233,6 +239,7 @@ oraz z tablicy ``defaults`` przechowującej wartości domyślne:
             defaults:  { _controller: AppBundle:Main:homepage }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -248,6 +255,7 @@ oraz z tablicy ``defaults`` przechowującej wartości domyślne:
         </routes>
 
     ..  code-block:: php
+        :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -278,6 +286,7 @@ Do określenia wielu tras można wykorzystać jedno lub więcej
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/BlogController.php
 
@@ -294,6 +303,7 @@ Do określenia wielu tras można wykorzystać jedno lub więcej
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         blog_show:
@@ -301,6 +311,7 @@ Do określenia wielu tras można wykorzystać jedno lub więcej
             defaults:  { _controller: AppBundle:Blog:show }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -315,6 +326,7 @@ Do określenia wielu tras można wykorzystać jedno lub więcej
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -349,6 +361,7 @@ wpisów na blogu wymyślonej aplikacji blogowej:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/BlogController.php
 
@@ -367,6 +380,7 @@ wpisów na blogu wymyślonej aplikacji blogowej:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         blog:
@@ -374,6 +388,7 @@ wpisów na blogu wymyślonej aplikacji blogowej:
             defaults:  { _controller: AppBundle:Blog:index }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -388,6 +403,7 @@ wpisów na blogu wymyślonej aplikacji blogowej:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -409,6 +425,7 @@ parameter ``{page}``:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/BlogController.php
 
@@ -423,6 +440,7 @@ parameter ``{page}``:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         blog:
@@ -430,6 +448,7 @@ parameter ``{page}``:
             defaults:  { _controller: AppBundle:Blog:index }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -444,6 +463,7 @@ parameter ``{page}``:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -470,6 +490,7 @@ zapis:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/BlogController.php
 
@@ -484,6 +505,7 @@ zapis:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         blog:
@@ -491,6 +513,7 @@ zapis:
             defaults:  { _controller: AppBundle:Blog:index, page: 1 }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -506,6 +529,7 @@ zapis:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -557,6 +581,7 @@ Spójrzmy na utworzone przez nas wcześniej trasy:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/BlogController.php
 
@@ -581,6 +606,7 @@ Spójrzmy na utworzone przez nas wcześniej trasy:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         blog:
@@ -592,6 +618,7 @@ Spójrzmy na utworzone przez nas wcześniej trasy:
             defaults:  { _controller: AppBundle:Blog:show }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -611,6 +638,7 @@ Spójrzmy na utworzone przez nas wcześniej trasy:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -651,6 +679,7 @@ wymagań może łatwo zostać dodane dla każdego parametru. Na przykład:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/BlogController.php
 
@@ -667,6 +696,7 @@ wymagań może łatwo zostać dodane dla każdego parametru. Na przykład:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         blog:
@@ -676,6 +706,7 @@ wymagań może łatwo zostać dodane dla każdego parametru. Na przykład:
                 page:  \d+
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -692,6 +723,7 @@ wymagań może łatwo zostać dodane dla każdego parametru. Na przykład:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -738,6 +770,7 @@ strona główna aplikacji jest dostępna w dwóch różnych językach, zależnie
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/MainController.php
 
@@ -755,6 +788,7 @@ strona główna aplikacji jest dostępna w dwóch różnych językach, zależnie
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         homepage:
@@ -764,6 +798,7 @@ strona główna aplikacji jest dostępna w dwóch różnych językach, zależnie
                 _locale:  en|fr
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -780,6 +815,7 @@ strona główna aplikacji jest dostępna w dwóch różnych językach, zależnie
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -822,6 +858,7 @@ Można to osiągnąć poprzez następującą konfigurację trasowania:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/MainController.php
         namespace AppBundle\Controller;
@@ -851,6 +888,7 @@ Można to osiągnąć poprzez następującą konfigurację trasowania:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         news:
@@ -864,6 +902,7 @@ Można to osiągnąć poprzez następującą konfigurację trasowania:
             methods:  [GET, POST]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -882,6 +921,7 @@ Można to osiągnąć poprzez następującą konfigurację trasowania:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -936,6 +976,7 @@ przy zastosowaniu *wyrażeń warunkowych*:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         contact:
             path:     /contact
@@ -943,6 +984,7 @@ przy zastosowaniu *wyrażeń warunkowych*:
             condition: "context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'"
 
     .. code-block:: xml
+       :linenos:
 
         <?xml version="1.0" encoding="UTF-8" ?>
         <routes xmlns="http://symfony.com/schema/routing"
@@ -957,6 +999,7 @@ przy zastosowaniu *wyrażeń warunkowych*:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         use Symfony\Component\Routing\RouteCollection;
         use Symfony\Component\Routing\Route;
@@ -1026,6 +1069,7 @@ trasowania:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/ArticleController.php
 
@@ -1049,6 +1093,7 @@ trasowania:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         article_show:
@@ -1060,6 +1105,7 @@ trasowania:
               year:     \d+
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1081,6 +1127,7 @@ trasowania:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -1261,6 +1308,7 @@ tego pliku:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         app:
@@ -1268,6 +1316,7 @@ tego pliku:
             type:     annotation # required to enable the Annotation reader for this resource
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1281,6 +1330,7 @@ tego pliku:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -1312,12 +1362,14 @@ w tym katalogu i wstawione do trasowania.
     .. configuration-block::
 
         .. code-block:: yaml
+           :linenos:
 
             # app/config/routing.yml
             app:
                 resource: "@AcmeOtherBundle/Resources/config/routing.yml"
 
         .. code-block:: xml
+           :linenos:
 
             <!-- app/config/routing.xml -->
             <?xml version="1.0" encoding="UTF-8" ?>
@@ -1330,6 +1382,7 @@ w tym katalogu i wstawione do trasowania.
             </routes>
 
         .. code-block:: php
+           :linenos:
 
             // app/config/routing.php
             use Symfony\Component\Routing\RouteCollection;
@@ -1351,6 +1404,7 @@ Na przykład załóżmy, że chcemy popzedzić wszystkie trasy w AppBundle z ``/
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         app:
@@ -1359,6 +1413,7 @@ Na przykład załóżmy, że chcemy popzedzić wszystkie trasy w AppBundle z ``/
             prefix:   /site
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1374,6 +1429,7 @@ Na przykład załóżmy, że chcemy popzedzić wszystkie trasy w AppBundle z ``/
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -1525,6 +1581,7 @@ W kolejnym rozdziale poznasz jak generować ścieżki URL w szablonach.
     `FOSJsRoutingBundle`_, można to zrobić dokładnie tak:
 
     .. code-block:: javascript
+       :linenos:
 
        var url = Routing.generate(
             'blog_show',
@@ -1562,12 +1619,14 @@ stosując pomocnicze funkcje szablonów:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         <a href="{{ path('blog_show', {'slug': 'my-blog-post'}) }}">
           Read this blog post.
         </a>
 
     .. code-block:: html+php
+       :linenos:
 
         <a href="<?php echo $view['router']->generate('blog_show', array(
             'slug' => 'my-blog-post',
@@ -1596,12 +1655,14 @@ W PHP trzeba przekazać ``true`` do  ``generate()``:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         <a href="{{ url('blog_show', {'slug': 'my-blog-post'}) }}">
           Read this blog post.
         </a>
 
     .. code-block:: html+php
+       :linenos:
 
         <a href="<?php echo $view['router']->generate('blog_show', array(
             'slug' => 'my-blog-post',

--- a/book/security.rst
+++ b/book/security.rst
@@ -44,6 +44,7 @@ Domyślna konfiguracja wygląda tak:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -60,6 +61,7 @@ Domyślna konfiguracja wygląda tak:
                     anonymous: ~
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -85,6 +87,7 @@ Domyślna konfiguracja wygląda tak:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -153,6 +156,7 @@ W celu jego aktywowania, dodajmy do węzła ``firewall`` klucz ``http_basic``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -165,6 +169,7 @@ W celu jego aktywowania, dodajmy do węzła ``firewall`` klucz ``http_basic``:
                     http_basic: ~
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -185,6 +190,7 @@ W celu jego aktywowania, dodajmy do węzła ``firewall`` klucz ``http_basic``:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -225,6 +231,7 @@ który wymaga uwierzytelnienia użytkownika dla tego adresu URL:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -239,6 +246,7 @@ który wymaga uwierzytelnienia użytkownika dla tego adresu URL:
                 - { path: ^/admin, roles: ROLE_ADMIN }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -261,6 +269,7 @@ który wymaga uwierzytelnienia użytkownika dla tego adresu URL:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -325,6 +334,7 @@ sztywnego ładowania informacji o użytkownikach bezpośrednio z pliku konfigura
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -341,6 +351,7 @@ sztywnego ładowania informacji o użytkownikach bezpośrednio z pliku konfigura
             # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -362,6 +373,7 @@ sztywnego ładowania informacji o użytkownikach bezpośrednio z pliku konfigura
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -414,6 +426,7 @@ Musimy więc dodać do konfiguracji klucz ``encoders``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -424,6 +437,7 @@ Musimy więc dodać do konfiguracji klucz ``encoders``:
             # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -443,6 +457,7 @@ Musimy więc dodać do konfiguracji klucz ``encoders``:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -499,7 +514,8 @@ Najlepszym algorytmem jest ``bcrypt``:
 .. configuration-block::
 
     .. code-block:: yaml
-
+       :linenos:
+    
         # app/config/security.yml
         security:
             # ...
@@ -510,6 +526,7 @@ Najlepszym algorytmem jest ``bcrypt``:
                     cost: 12
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -531,6 +548,7 @@ Najlepszym algorytmem jest ``bcrypt``:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -554,6 +572,7 @@ które daje coś takiego:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -571,6 +590,7 @@ które daje coś takiego:
                                 roles: 'ROLE_ADMIN'
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -593,6 +613,7 @@ które daje coś takiego:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -747,6 +768,7 @@ roli ``ROLE_ADMIN`` dla takiej ścieżki:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -762,6 +784,7 @@ roli ``ROLE_ADMIN`` dla takiej ścieżki:
                 - { path: ^/admin, roles: ROLE_ADMIN }
 
     .. code-block:: xml
+       :linenos: 
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -784,6 +807,7 @@ roli ``ROLE_ADMIN`` dla takiej ścieżki:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -812,6 +836,7 @@ przeszukiwał je od początku do końca i zatrzma się, jak tylko znajdzie wpis
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -822,6 +847,7 @@ przeszukiwał je od początku do końca i zatrzma się, jak tylko znajdzie wpis
                 - { path: ^/admin, roles: ROLE_ADMIN }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -840,6 +866,7 @@ przeszukiwał je od początku do końca i zatrzma się, jak tylko znajdzie wpis
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -939,12 +966,14 @@ rolę, trzeba użyć wbudowanej funkcji pomocniczej:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {% if is_granted('ROLE_ADMIN') %}
             <a href="...">Delete</a>
         {% endif %}
 
     .. code-block:: html+php
+       :linenos: 
 
         <?php if ($view['security']->isGranted('ROLE_ADMIN')): ?>
             <a href="...">Delete</a>
@@ -1023,6 +1052,7 @@ Można te używać wyrażenia wewnątrz szablonów:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {% if is_granted(expression(
             '"ROLE_ADMIN" in roles or (user and user.isSuperAdmin())'
@@ -1031,6 +1061,7 @@ Można te używać wyrażenia wewnątrz szablonów:
         {% endif %}
 
     .. code-block:: html+php
+       :linenos:
 
         <?php if ($view['security']->isGranted(new Expression(
             '"ROLE_ADMIN" in roles or (user and user.isSuperAdmin())'
@@ -1142,12 +1173,14 @@ W szablonie Twig obiekt ten może być dostępny poprzez klucz :ref:`app.user <r
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {% if is_granted('IS_AUTHENTICATED_FULLY') %}
             <p>Username: {{ app.user.username }}</p>
         {% endif %}
 
     .. code-block:: html+php
+       :linenos:
 
         <?php if ($view['security']->isGranted('IS_AUTHENTICATED_FULLY')): ?>
             <p>Username: <?php echo $app->getUser()->getUsername() ?></p>
@@ -1168,6 +1201,7 @@ parametr ``logout``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -1181,6 +1215,7 @@ parametr ``logout``:
                         target: /
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -1201,6 +1236,7 @@ parametr ``logout``:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -1219,12 +1255,14 @@ Następnie musi się utworzyć trasę dla tej ścieżki URL (ale nie akję):
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         logout:
             path: /logout
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1237,6 +1275,7 @@ Następnie musi się utworzyć trasę dla tej ścieżki URL (ale nie akję):
         </routes>
 
     ..  code-block:: php
+        :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -1313,6 +1352,7 @@ rół, tworząc hierarchie ról:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -1323,6 +1363,7 @@ rół, tworząc hierarchie ról:
                 ROLE_SUPER_ADMIN: [ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -1341,6 +1382,7 @@ rół, tworząc hierarchie ról:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -1372,6 +1414,7 @@ między żądaniami, można aktywować uwierzytelnianie bezstanowe (co oznacza, 
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -1383,6 +1426,7 @@ między żądaniami, można aktywować uwierzytelnianie bezstanowe (co oznacza, 
                     stateless:  true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -1402,6 +1446,7 @@ między żądaniami, można aktywować uwierzytelnianie bezstanowe (co oznacza, 
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -1452,7 +1497,7 @@ w przypadku indywidualnych wymagań, takich jak własna strategia uwierzytelnian
 tematyka bezpieczeństwa jest skomplikowana!).
 
 Na szczęście, istnieje
-:doc:`działt Receptariusza poświecony bezpieczeństwu </cookbook/security/index>`,
+:doc:`dział Receptariusza poświecony bezpieczeństwu </cookbook/security/index>`,
 gdzie można znaleźć artykuły poruszające zagadnienia nie omówione przez nas.
 Można też skorzystać z rozdziału :doc:`Informator bezpieczeństwa </reference/configuration/security>`.
 

--- a/book/service_container.rst
+++ b/book/service_container.rst
@@ -163,6 +163,7 @@ Parametry czynią zdefiniowane usługi lepiej zorganizowanymi i bardziej elastyc
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         parameters:
@@ -174,6 +175,7 @@ Parametry czynią zdefiniowane usługi lepiej zorganizowanymi i bardziej elastyc
                 arguments:    ["%my_mailer.transport%"]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -194,6 +196,7 @@ Parametry czynią zdefiniowane usługi lepiej zorganizowanymi i bardziej elastyc
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         use Symfony\Component\DependencyInjection\Definition;
@@ -219,6 +222,7 @@ one użyte w definicji usługi.
     tylko znaczenie w formacie YAML):
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/parameters.yml
         parameters:
@@ -302,6 +306,7 @@ kontenera wewnątrz ``AcmeHelloBundle``. Jeśli jeszcze nie istnieją katalogi
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # src/Acme/HelloBundle/Resources/config/services.yml
         parameters:
@@ -313,6 +318,7 @@ kontenera wewnątrz ``AcmeHelloBundle``. Jeśli jeszcze nie istnieją katalogi
                 arguments:    ["%my_mailer.transport%"]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -333,6 +339,7 @@ kontenera wewnątrz ``AcmeHelloBundle``. Jeśli jeszcze nie istnieją katalogi
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/HelloBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
@@ -351,12 +358,14 @@ zasobu używając klucza ``imports`` w konfiguracji aplikacji.
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         imports:
             - { resource: "@AcmeHelloBundle/Resources/config/services.yml" }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -371,6 +380,7 @@ zasobu używając klucza ``imports`` w konfiguracji aplikacji.
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $loader->import('@AcmeHelloBundle/Resources/config/services.php');
@@ -423,6 +433,7 @@ wewnątrz ``FrameworkBundle``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -433,6 +444,7 @@ wewnątrz ``FrameworkBundle``:
             # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -453,6 +465,7 @@ wewnątrz ``FrameworkBundle``:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -562,6 +575,7 @@ rozwiązanie:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # src/Acme/HelloBundle/Resources/config/services.yml
         services:
@@ -573,6 +587,7 @@ rozwiązanie:
                 arguments: ["@my_mailer"]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -593,6 +608,7 @@ rozwiązanie:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/HelloBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
@@ -639,6 +655,7 @@ wyrażenia:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         services:
@@ -647,6 +664,7 @@ wyrażenia:
                 arguments:    ["@=service('mailer_configuration').getMailerMethod()"]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -664,6 +682,7 @@ wyrażenia:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         use Symfony\Component\DependencyInjection\Definition;
@@ -690,6 +709,7 @@ poprzez zmienną ``container``. Oto inny przykład:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         services:
             my_mailer:
@@ -697,6 +717,7 @@ poprzez zmienną ``container``. Oto inny przykład:
                 arguments: ["@=container.hasParameter('some_param') ? parameter('some_param') : 'default_value'"]
 
     .. code-block:: xml
+       :linenos:
 
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
@@ -713,6 +734,7 @@ poprzez zmienną ``container``. Oto inny przykład:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         use Symfony\Component\DependencyInjection\Definition;
         use Symfony\Component\ExpressionLanguage\Expression;
@@ -767,6 +789,7 @@ Wstrzykiwanie zależności przez metodę setera wymaga zmiany składni:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # src/Acme/HelloBundle/Resources/config/services.yml
         services:
@@ -779,6 +802,7 @@ Wstrzykiwanie zależności przez metodę setera wymaga zmiany składni:
                     - [setMailer, ["@my_mailer"]]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -801,6 +825,7 @@ Wstrzykiwanie zależności przez metodę setera wymaga zmiany składni:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/HelloBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
@@ -863,6 +888,7 @@ inna usługa:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # src/Acme/HelloBundle/Resources/config/services.yml
         services:
@@ -871,6 +897,7 @@ inna usługa:
                 arguments: ["@request_stack"]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -889,6 +916,7 @@ inna usługa:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/HelloBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
@@ -933,6 +961,7 @@ opcjonalną. Kontener wstrzyknie ją, jeśli istnieje, jeśli nie, to nic się n
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # src/Acme/HelloBundle/Resources/config/services.yml
         services:
@@ -941,6 +970,7 @@ opcjonalną. Kontener wstrzyknie ją, jeśli istnieje, jeśli nie, to nic się n
                 arguments: ["@?my_mailer"]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -961,6 +991,7 @@ opcjonalną. Kontener wstrzyknie ją, jeśli istnieje, jeśli nie, to nic się n
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/HelloBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Definition;
@@ -1050,6 +1081,7 @@ Konfiguracja kontenera usług jest łatwa:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # src/Acme/HelloBundle/Resources/config/services.yml
         services:
@@ -1058,6 +1090,7 @@ Konfiguracja kontenera usług jest łatwa:
                 arguments: ["@mailer", "@templating"]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/HelloBundle/Resources/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1073,6 +1106,7 @@ Konfiguracja kontenera usług jest łatwa:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/HelloBundle/Resources/config/services.php
         $container->setDefinition('newsletter_manager', new Definition(
@@ -1110,6 +1144,7 @@ użyta w określonym celu. Weźmy następujący przykład:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/services.yml
         services:
@@ -1120,6 +1155,7 @@ użyta w określonym celu. Weźmy następujący przykład:
                     -  { name: twig.extension }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1138,6 +1174,7 @@ użyta w określonym celu. Weźmy następujący przykład:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/services.php
         use Symfony\Component\DependencyInjection\Definition;

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -34,6 +34,7 @@ Szablon jest plikiem tekstowym mogącym wygenerować dowolny format tekstowy
 PHP* - plik tekstowy parsowany przez PHP, który zawiera mieszankę tekstu i kodu PHP:
 
 .. code-block:: html+php
+   :linenos:
 
     <!DOCTYPE html>
     <html>
@@ -62,6 +63,7 @@ o nazwie `Twig`_. Twig pozwala pisać zwięzłe, czytelne szablony na kilka spos
 które są bardziej przyjazne dla projektantów stron i są bardziej wydajne niż szablony PHP:
 
 .. code-block:: html+jinja
+   :linenos:
 
     <!DOCTYPE html>
     <html>
@@ -200,6 +202,7 @@ Po pierwsze, zbuduj podstawowy plik układu strony:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/base.html.twig #}
         <!DOCTYPE html>
@@ -225,6 +228,7 @@ Po pierwsze, zbuduj podstawowy plik układu strony:
         </html>
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/base.html.php -->
         <!DOCTYPE html>
@@ -269,6 +273,7 @@ Szablon potomny może wyglądać tak:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/blog/index.html.twig #}
         {% extends 'base.html.twig' %}
@@ -283,6 +288,7 @@ Szablon potomny może wyglądać tak:
         {% endblock %}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/blog/index.html.php -->
         <?php $view->extend('base.html.php') ?>
@@ -311,6 +317,7 @@ przez bloki z szablonu potomnego. W zależności od wartości ``blog_entries`` w
 może wyglądać następująco:
 
 .. code-block:: html
+   :linenos:
 
     <!DOCTYPE html>
     <html>
@@ -635,6 +642,7 @@ Szablon ``recentList`` jest bardzo prosty:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/article/recent_list.html.twig #}
         {% for article in articles %}
@@ -644,6 +652,7 @@ Szablon ``recentList`` jest bardzo prosty:
         {% endfor %}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/article/recent_list.html.php -->
         <?php foreach ($articles as $article): ?>
@@ -665,6 +674,7 @@ Dla dołączenia kontrolera, trzeba się do niego odwołać używając standardo
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/base.html.twig #}
 
@@ -677,6 +687,7 @@ Dla dołączenia kontrolera, trzeba się do niego odwołać używając standardo
         </div>
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/base.html.php -->
 
@@ -712,11 +723,13 @@ do konfigurowania znaczników ``hinclude.js``:
 .. configuration-block::
 
     .. code-block:: jinja
+       :linenos:
 
         {{ render_hinclude(controller('...')) }}
         {{ render_hinclude(url('...')) }}
 
     .. code-block:: php
+       :linenos:
 
         <?php echo $view['actions']->render(
             new ControllerReference('...'),
@@ -779,6 +792,7 @@ JavaScript) można ustawić w konfiguracji aplikacji:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -787,6 +801,7 @@ JavaScript) można ustawić w konfiguracji aplikacji:
                 hinclude_default_template: hinclude.html.twig
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -803,6 +818,7 @@ JavaScript) można ustawić w konfiguracji aplikacji:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -822,12 +838,14 @@ wszystkie zdefiniowane globalne szablony):
 .. configuration-block::
 
     .. code-block:: jinja
+       :linenos:
 
         {{ render_hinclude(controller('...'),  {
             'default': 'default/content.html.twig'
         }) }}
 
     .. code-block:: php
+       :linenos:
 
         <?php echo $view['actions']->render(
             new ControllerReference('...'),
@@ -842,10 +860,11 @@ albo można również określić łańcuch tekstowy do wyświetlenia jako domyś
 .. configuration-block::
 
     .. code-block:: jinja
-
+       
         {{ render_hinclude(controller('...'), {'default': 'Loading...'}) }}
 
     .. code-block:: php
+       :linenos:
 
         <?php echo $view['actions']->render(
             new ControllerReference('...'),
@@ -878,6 +897,7 @@ konfigurację trasowania:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         _welcome:
@@ -885,6 +905,7 @@ konfigurację trasowania:
             defaults: { _controller: AppBundle:Welcome:index }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.yml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -899,6 +920,7 @@ konfigurację trasowania:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\Route;
@@ -931,6 +953,7 @@ z bardziej skomplikowaną trasą:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         article_show:
@@ -938,6 +961,7 @@ z bardziej skomplikowaną trasą:
             defaults: { _controller: AppBundle:Article:show }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -952,6 +976,7 @@ z bardziej skomplikowaną trasą:
         </routes>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\Route;
@@ -971,6 +996,7 @@ jak i wartość parametru ``{slug}``. Używając tej trasy, przeróbmy szablon
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/article/recent_list.html.twig #}
         {% for article in articles %}
@@ -980,6 +1006,7 @@ jak i wartość parametru ``{slug}``. Używając tej trasy, przeróbmy szablon
         {% endfor %}
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/Article/recent_list.html.php -->
         <?php foreach ($articles in $article): ?>
@@ -1010,6 +1037,7 @@ jak i wartość parametru ``{slug}``. Używając tej trasy, przeróbmy szablon
     the ``generate()`` method:
 
     .. code-block:: html+php
+       :linenos:
 
         <a href="<?php echo $view['router']->generate(
             '_welcome',
@@ -1072,6 +1100,7 @@ Jeśli chce się ustawić wersję dla określonego aktywa, można ustawić czwar
         <img src="{{ asset('images/logo.png', version='3.0') }}" alt="Symfony!" />
 
     .. code-block:: html+php
+       :linenos: 
 
         <img src="<?php echo $view['assets']->getUrl(
             'images/logo.png',
@@ -1094,6 +1123,7 @@ argument (lub argument ``absolute``) na ``true``:
         <img src="{{ asset('images/logo.png', absolute=true) }}" alt="Symfony!" />
 
     .. code-block:: html+php
+       :linenos:
 
         <img src="<?php echo $view['assets']->getUrl(
             'images/logo.png',
@@ -1134,6 +1164,7 @@ potrzebne w całej witrynie:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/base.html.twig #}
         <html>
@@ -1154,6 +1185,7 @@ potrzebne w całej witrynie:
         </html>
 
     .. code-block:: php
+       :linenos:
 
         // app/Resources/views/base.html.php
         <html>
@@ -1181,6 +1213,7 @@ Wewnątrz szablonu strony kontaktowej trzeba zrobić co następuje:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/contact/contact.html.twig #}
         {% extends 'base.html.twig' %}
@@ -1194,6 +1227,7 @@ Wewnątrz szablonu strony kontaktowej trzeba zrobić co następuje:
         {# ... #}
 
     .. code-block:: php
+       :linenos:
 
         // app/Resources/views/contact/contact.html.twig
         <?php $view->extend('base.html.php') ?>
@@ -1262,6 +1296,7 @@ dającej automatyczny dostęp do określonych zmiennych:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         <p>Username: {{ app.user.username }}</p>
         {% if app.debug %}
@@ -1270,6 +1305,7 @@ dającej automatyczny dostęp do określonych zmiennych:
         {% endif %}
 
     .. code-block:: html+php
+       :linenos:
 
         <p>Username: <?php echo $app->getUser()->getUsername() ?></p>
         <?php if ($app->getDebug()): ?>
@@ -1319,6 +1355,7 @@ aplikacji:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -1326,6 +1363,7 @@ aplikacji:
             templating: { engines: ['twig'] }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1344,6 +1382,7 @@ aplikacji:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -1464,6 +1503,7 @@ Ta metoda działa doskonale z trzema różnymi typami szablonów, które właśn
   elementy specyficzne dla blogu:
 
   .. code-block:: html+jinja
+     :linenos:
 
       {# app/Resources/views/blog/layout.html.twig #}
       {% extends 'base.html.twig' %}
@@ -1479,6 +1519,7 @@ Ta metoda działa doskonale z trzema różnymi typami szablonów, które właśn
   ``AppBundle:Blog:index.html.twig`` i zawierać będzie wykaz aktualnych wpisów blogu:
 
   .. code-block:: html+jinja
+     :linenos:
 
       {# app/Resources/views/blog/index.html.twig #}
       {% extends 'blog/layout.html.twig' %}
@@ -1634,6 +1675,7 @@ na przykład wewnątrz kontrolera::
 Ten sam mechanizm może zostać uzyty w szablonach Twig dzięki funkcji ``dump``:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {# app/Resources/views/article/recent_list.html.twig #}
     {{ dump(articles) }}
@@ -1704,12 +1746,14 @@ z parametrem asocjacyjnym:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         <a href="{{ path('article_show', {'id': 123, '_format': 'pdf'}) }}">
             PDF Version
         </a>
 
     .. code-block:: html+php
+       :linenos:
 
         <a href="<?php echo $view['router']->generate('article_show', array(
             'id' => 123,

--- a/book/translation.rst
+++ b/book/translation.rst
@@ -73,12 +73,14 @@ w konfiguracji:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
             translator: { fallbacks: [en] }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -98,6 +100,7 @@ w konfiguracji:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -607,12 +610,14 @@ definiując klucz ``default_locale`` w opcji ``framework``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
             default_locale: en
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -628,6 +633,7 @@ definiując klucz ``default_locale`` w opcji ``framework``:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -822,6 +828,7 @@ w AppBundle:
 .. configuration-block::
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/AppBundle/Resources/translations/messages.fr.xlf -->
         <?xml version="1.0"?>
@@ -838,11 +845,13 @@ w AppBundle:
 
 
     .. code-block:: yaml
+       :linenos:
 
         # src/Acme/AcmeDemoBundle/Resources/translations/messages.fr.yml
         Symfony is great: J'aime Symfony
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/AcmeDemoBundle/Resources/translations/messages.fr.php
         return array(
@@ -855,6 +864,7 @@ a dla ustawienia ``en``:
 .. configuration-block::
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/Acme/AppBundle/Resources/translations/messages.en.xlf -->
         <?xml version="1.0"?>
@@ -870,11 +880,13 @@ a dla ustawienia ``en``:
         </xliff>
 
     .. code-block:: yaml
+       :linenos:
 
         # src/Acme/AppBundle/Resources/translations/messages.en.yml
         Symfony is great: Symfony is great
 
     .. code-block:: php
+       :linenos:
 
         // src/Acme/AppBundle/Resources/translations/messages.en.php
         return array(

--- a/book/validation.rst
+++ b/book/validation.rst
@@ -52,6 +52,7 @@ trzeba dodać następujący kod:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -67,6 +68,7 @@ trzeba dodać następujący kod:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\Author:
@@ -75,6 +77,7 @@ trzeba dodać następujący kod:
                     - NotBlank: ~
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -90,6 +93,7 @@ trzeba dodać następujący kod:
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -192,6 +196,7 @@ Jeśli zachodzi taka potrzeba, to można w szablonie wyprowadzić listę błęd�
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/author/validation.html.twig #}
         <h3>The author has the following errors</h3>
@@ -202,6 +207,7 @@ Jeśli zachodzi taka potrzeba, to można w szablonie wyprowadzić listę błęd�
         </ul>
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/author/validation.html.php -->
         <h3>The author has the following errors</h3>
@@ -278,12 +284,14 @@ adnotacji, to należy określić to w ograniczeniach:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
             validation: { enable_annotations: true }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -299,6 +307,7 @@ adnotacji, to należy określić to w ograniczeniach:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -354,6 +363,7 @@ mają kilka dostępnych opcji konfiguracji. Załóżmy, że klasa ``Author`` ma 
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -374,6 +384,7 @@ mają kilka dostępnych opcji konfiguracji. Załóżmy, że klasa ``Author`` ma 
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\Author:
@@ -383,6 +394,7 @@ mają kilka dostępnych opcji konfiguracji. Załóżmy, że klasa ``Author`` ma 
                 # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -407,6 +419,7 @@ mają kilka dostępnych opcji konfiguracji. Załóżmy, że klasa ``Author`` ma 
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -442,6 +455,7 @@ w ten sposób.
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -459,6 +473,7 @@ w ten sposób.
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\Author:
@@ -468,6 +483,7 @@ w ten sposób.
                 # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -489,6 +505,7 @@ w ten sposób.
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -555,6 +572,7 @@ klasy ``Author``, której wartość powinna mieć co najmniej 3 znaki.
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // AppBundle/Entity/Author.php
 
@@ -571,6 +589,7 @@ klasy ``Author``, której wartość powinna mieć co najmniej 3 znaki.
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\Author:
@@ -581,6 +600,7 @@ klasy ``Author``, której wartość powinna mieć co najmniej 3 znaki.
                         min: 3
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -599,6 +619,7 @@ klasy ``Author``, której wartość powinna mieć co najmniej 3 znaki.
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -641,6 +662,7 @@ i następnie zrobić załóżenie, że metoda ta musi zwrócić ``true``:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -659,6 +681,7 @@ i następnie zrobić załóżenie, że metoda ta musi zwrócić ``true``:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\Author:
@@ -667,6 +690,7 @@ i następnie zrobić załóżenie, że metoda ta musi zwrócić ``true``:
                     - "True": { message: "The password cannot match your first name" }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -684,6 +708,7 @@ i następnie zrobić załóżenie, że metoda ta musi zwrócić ``true``:
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/Author.php
 
@@ -742,6 +767,7 @@ rejestracji użytkownika jak i podczas aktualizowania jego informacji kontaktowy
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/User.php
         namespace AppBundle\Entity;
@@ -769,6 +795,7 @@ rejestracji użytkownika jak i podczas aktualizowania jego informacji kontaktowy
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\User:
@@ -783,6 +810,7 @@ rejestracji użytkownika jak i podczas aktualizowania jego informacji kontaktowy
                         min: 2
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -825,6 +853,7 @@ rejestracji użytkownika jak i podczas aktualizowania jego informacji kontaktowy
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/User.php
         namespace AppBundle\Entity;
@@ -924,6 +953,7 @@ uniknięcia wielu komunikatów o błędach).
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/User.php
         namespace AppBundle\Entity;
@@ -956,6 +986,7 @@ uniknięcia wielu komunikatów o błędach).
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\User:
@@ -974,6 +1005,7 @@ uniknięcia wielu komunikatów o błędach).
                     - NotBlank: ~
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1007,6 +1039,7 @@ uniknięcia wielu komunikatów o błędach).
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/User.php
         namespace AppBundle\Entity;
@@ -1060,6 +1093,7 @@ i nowe ograniczenie o nazwie``Premium``:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/User.php
         namespace AppBundle\Entity;
@@ -1085,6 +1119,7 @@ i nowe ograniczenie o nazwie``Premium``:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\User:
@@ -1097,6 +1132,7 @@ i nowe ograniczenie o nazwie``Premium``:
                         groups: [Premium]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1125,6 +1161,7 @@ i nowe ograniczenie o nazwie``Premium``:
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/User.php
         namespace AppBundle\Entity;
@@ -1184,6 +1221,7 @@ sekwencję grup do zastosowania w walidacji:
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Entity/User.php
         namespace AppBundle\Entity;
@@ -1199,12 +1237,14 @@ sekwencję grup do zastosowania w walidacji:
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # src/AppBundle/Resources/config/validation.yml
         AppBundle\Entity\User:
             group_sequence_provider: true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- src/AppBundle/Resources/config/validation.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1220,6 +1260,7 @@ sekwencję grup do zastosowania w walidacji:
         </constraint-mapping>
 
     .. code-block:: php
+       :linenos:
 
         // src/AppBundle/Entity/User.php
         namespace AppBundle\Entity;

--- a/components/using_components.rst
+++ b/components/using_components.rst
@@ -1,3 +1,6 @@
+.. highlight:: php
+   :linenothreshold: 2
+
 .. index::
    single: komponenty; instalacja
    single: komponenty; stosowanie

--- a/cookbook/email/cloud.rst
+++ b/cookbook/email/cloud.rst
@@ -30,6 +30,7 @@ podając wartości ``username`` i ``password``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         swiftmailer:
@@ -41,6 +42,7 @@ podając wartości ``username`` i ``password``:
             password:   AWS_SECRET_KEY  # to be created in the SES console
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -64,6 +66,7 @@ podając wartości ``username`` i ``password``:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('swiftmailer', array(
@@ -89,6 +92,7 @@ Jak sie to zrobi, można zacząć wysyłanie wiadomości email przez chmurę!
     produkcyjnym.
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/parameters.yml
         parameters:

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -2,8 +2,8 @@
    single: wiadomości email; w trakcie programowania
 
 
-Jak pracować z pocztą elektroniczną podczas programoania
-========================================================
+Jak pracować z pocztą elektroniczną podczas programowania
+=========================================================
 
 Kiedy tworzysz aplikację wysyłającą wiadomości email, raczej nie będziesz chciał
 ich wysyłać do rzeczywistych odbiorców w czasie prac programistycznych.
@@ -27,12 +27,14 @@ oraz ``dev``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config_test.yml
         swiftmailer:
             disable_delivery:  true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config_test.xml -->
 
@@ -45,6 +47,7 @@ oraz ``dev``:
             disable-delivery="true" />
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config_test.php
         $container->loadFromExtension('swiftmailer', array(
@@ -64,12 +67,14 @@ Robi się to ustawiając odpowiednio opcje ``delivery_address``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config_dev.yml
         swiftmailer:
             delivery_address:  dev@example.com
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config_dev.xml -->
 
@@ -82,6 +87,7 @@ Robi się to ustawiając odpowiednio opcje ``delivery_address``:
             delivery-address="dev@example.com" />
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config_dev.php
         $container->loadFromExtension('swiftmailer', array(
@@ -91,6 +97,7 @@ Robi się to ustawiając odpowiednio opcje ``delivery_address``:
 Wyobrażmy sobie teraz, że wysyła się wiadomość na adres ``recipient@example.com``:
 
 .. code-block:: php
+   :linenos:
 
     public function indexAction($name)
     {
@@ -131,6 +138,7 @@ opcję ``delivery_whitelist``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos: 
 
         # app/config/config_dev.yml
         swiftmailer:
@@ -145,6 +153,7 @@ opcję ``delivery_whitelist``:
                - "/^admin@mydomain.com$/"
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config_dev.xml -->
 
@@ -160,7 +169,8 @@ opcję ``delivery_whitelist``:
             <swiftmailer:delivery-whitelist-pattern>/^admin@mydomain.com$/</swiftmailer:delivery-whitelist-pattern>
         </swiftmailer:config>
 
-    .. code-block:: php
+    .. code-block:: php 
+       :linenos:
 
         // app/config/config_dev.php
         $container->loadFromExtension('swiftmailer', array(
@@ -200,12 +210,14 @@ otworzenie raportu ze szczegółowymi informacjami o wysłanych wiadomościach.
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config_dev.yml
         web_profiler:
             intercept_redirects: true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config_dev.xml -->
 
@@ -220,6 +232,7 @@ otworzenie raportu ze szczegółowymi informacjami o wysłanych wiadomościach.
         />
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config_dev.php
         $container->loadFromExtension('web_profiler', array(

--- a/cookbook/email/email.rst
+++ b/cookbook/email/email.rst
@@ -1,3 +1,6 @@
+.. highlight:: php
+   :linenothreshold: 2
+
 .. index::
    wiadomości email, poczta elektroniczna
 
@@ -32,6 +35,7 @@ W standardowej instalacji Symfony jest już zawarta pewna konfiguracja
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         swiftmailer:
@@ -41,6 +45,7 @@ W standardowej instalacji Symfony jest już zawarta pewna konfiguracja
             password:  "%mailer_password%"
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
 
@@ -56,6 +61,7 @@ W standardowej instalacji Symfony jest już zawarta pewna konfiguracja
             password="%mailer_password%" />
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('swiftmailer', array(
@@ -129,6 +135,7 @@ jest umieszczane w szablonie i renderowane przez metodę ``renderView()``. Szabl
 ``registration.html.twig`` może wyglądać podobnie do tego:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {# app/Resources/views/Emails/registration.html.twig #}
     <h3>You did it! You registered!</h3>

--- a/cookbook/email/gmail.rst
+++ b/cookbook/email/gmail.rst
@@ -21,6 +21,7 @@ na ``gmail`` i ustawić ``username`` i ``password`` zgodnie z poświadczeniem Go
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config_dev.yml
         swiftmailer:
@@ -29,6 +30,7 @@ na ``gmail`` i ustawić ``username`` i ``password`` zgodnie z poświadczeniem Go
             password:  your_gmail_password
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config_dev.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -49,6 +51,7 @@ na ``gmail`` i ustawić ``username`` i ``password`` zgodnie z poświadczeniem Go
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config_dev.php
         $container->loadFromExtension('swiftmailer', array(
@@ -65,6 +68,7 @@ Gotowe!
     pliku ``parameters.yml``:
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/parameters.yml
         parameters:

--- a/cookbook/email/spool.rst
+++ b/cookbook/email/spool.rst
@@ -28,6 +28,7 @@ pamięci trzeba ustawić następującą konfigurację:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         swiftmailer:
@@ -35,6 +36,7 @@ pamięci trzeba ustawić następującą konfigurację:
             spool: { type: memory }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
 
@@ -49,6 +51,7 @@ pamięci trzeba ustawić następującą konfigurację:
         </swiftmailer:config>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('swiftmailer', array(
@@ -65,6 +68,7 @@ konfigurację:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         swiftmailer:
@@ -74,6 +78,7 @@ konfigurację:
                 path: /path/to/spool
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
 
@@ -90,6 +95,7 @@ konfigurację:
         </swiftmailer:config>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('swiftmailer', array(

--- a/cookbook/email/testing.rst
+++ b/cookbook/email/testing.rst
@@ -1,3 +1,6 @@
+.. highlight:: php
+   :linenothreshold: 2
+
 .. index::
    testowanie poczty elektronicznej
    single: wiadomości email; testowanie

--- a/cookbook/security/access_control.rst
+++ b/cookbook/security/access_control.rst
@@ -35,7 +35,8 @@ Dla przykładu zastosujmy następujące wpisy ``access_control``::
 .. configuration-block::
 
     .. code-block:: yaml
-
+       :linenos:
+       
         # app/config/security.yml
         security:
             # ...
@@ -46,6 +47,7 @@ Dla przykładu zastosujmy następujące wpisy ``access_control``::
                 - { path: ^/admin, roles: ROLE_USER }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -65,6 +67,7 @@ Dla przykładu zastosujmy następujące wpisy ``access_control``::
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -160,7 +163,7 @@ Po tym jak Symfony określi, który wpis ``access_control`` zostanie użyty
 Zabezpieczanie przez IP
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-W pewnych sytuacjach moze zachodzić potrzeba sformułowania wpisu ``access_control``,
+W pewnych sytuacjach może zachodzić potrzeba sformułowania wpisu ``access_control``,
 który dopasowuje żądania przychodzące tylko z jakiegość adresu IP lub zakresu
 takich adresów. Można to wykorzystać, na przykład, do ograniczenia dostępu do
 adresów pasujących do jakiegoś wzorca URL, z wyjatkiem żądań przychodzących
@@ -168,7 +171,7 @@ z zaufanego serwera wewnetrznego.
 
 .. caution::
 
-    Jak mozna przeczytać w wyjaśnieniu ponizeszego przykładu, opcja ``ips``
+    Jak można przeczytać w wyjaśnieniu poniżeszego przykładu, opcja ``ips``
     nie ogranicza się do konkretnego adresu IP. Zastosowanie klucza ``ips``
     oznacza, że ten wpis ``access_control`` będzie tylko dopasowywał tylko ten
     adres IP i udzielał użytkownikom nadal dostępu z innych adresów IP wyszczególnionych
@@ -180,6 +183,7 @@ aby dostępne były tylko żądania z lokalnego serwera:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -190,6 +194,7 @@ aby dostępne były tylko żądania z lokalnego serwera:
                 - { path: ^/internal, roles: ROLE_NO_ACCESS }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -211,6 +216,7 @@ aby dostępne były tylko żądania z lokalnego serwera:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -266,6 +272,7 @@ Po dopasowaniu wpisu ``access_control``, mozna odmówić dostępu stosując kluc
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -276,6 +283,7 @@ Po dopasowaniu wpisu ``access_control``, mozna odmówić dostępu stosując kluc
                     allow_if: "'127.0.0.1' == request.getClientIp() or has_role('ROLE_ADMIN')"
 
     .. code-block:: xml
+       :linenos:
 
             <access-control>
                 <rule path="^/_internal/secure"
@@ -283,6 +291,7 @@ Po dopasowaniu wpisu ``access_control``, mozna odmówić dostępu stosując kluc
             </access-control>
 
     .. code-block:: php
+       :linenos:
 
             'access_control' => array(
                 array(
@@ -320,6 +329,7 @@ to uzytkownik zostanie przekierowany do ``https``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -328,6 +338,7 @@ to uzytkownik zostanie przekierowany do ``https``:
                 - { path: ^/cart/checkout, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -344,6 +355,7 @@ to uzytkownik zostanie przekierowany do ``https``:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(

--- a/cookbook/security/csrf_in_login_form.rst
+++ b/cookbook/security/csrf_in_login_form.rst
@@ -25,6 +25,7 @@ był dostawca domyślny, dostępny w komponencie Security:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -38,6 +39,7 @@ był dostawca domyślny, dostępny w komponencie Security:
                         csrf_provider: security.csrf.token_manager
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -58,6 +60,7 @@ był dostawca domyślny, dostępny w komponencie Security:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -90,6 +93,7 @@ formularza logowania:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# src/Acme/SecurityBundle/Resources/views/Security/login.html.twig #}
 
@@ -105,6 +109,7 @@ formularza logowania:
         </form>
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- src/Acme/SecurityBundle/Resources/views/Security/login.html.php -->
 
@@ -130,6 +135,7 @@ Teraz, formularz logowania jest już zabezpieczony przed atakami CSRF.
     .. configuration-block::
 
         .. code-block:: yaml
+           :linenos:
 
             # app/config/security.yml
             security:
@@ -144,6 +150,7 @@ Teraz, formularz logowania jest już zabezpieczony przed atakami CSRF.
                             intention: a_private_string
 
         .. code-block:: xml
+           :linenos:
 
             <!-- app/config/security.xml -->
             <?xml version="1.0" encoding="UTF-8" ?>
@@ -166,6 +173,7 @@ Teraz, formularz logowania jest już zabezpieczony przed atakami CSRF.
             </srv:container>
 
         .. code-block:: php
+           :linenos:
 
             // app/config/security.php
             $container->loadFromExtension('security', array(

--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -1,3 +1,6 @@
+.. highlight:: php
+   :linenothreshold: 2
+
 .. index::
    single: bezpieczeństwo; dostawca użytkowników
    single: bezpieczeństwo; dostawca z encji
@@ -43,6 +46,7 @@ Dla celów tego artykułu przyjmijmy, ze mamy już encję ``User`` wewnatrz paki
 ``email`` i ``isActive``:
 
 .. code-block:: php
+   :linenos:
 
     // src/AppBundle/Entity/User.php
     namespace AppBundle\Entity;
@@ -204,6 +208,7 @@ do nazwy użytkownika i sprawdzać hasło (o haśle więcej za moment):
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -230,6 +235,7 @@ do nazwy użytkownika i sprawdzać hasło (o haśle więcej za moment):
             # ...
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -259,6 +265,7 @@ do nazwy użytkownika i sprawdzać hasło (o haśle więcej za moment):
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -505,6 +512,7 @@ w ``security.yml``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -516,6 +524,7 @@ w ``security.yml``:
                         class: AppBundle:User
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -535,6 +544,7 @@ w ``security.yml``:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(

--- a/cookbook/security/form_login.rst
+++ b/cookbook/security/form_login.rst
@@ -52,6 +52,7 @@ trasę ``default_security_target``, trzeba użyć następującej konfiguracji:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -64,6 +65,7 @@ trasę ``default_security_target``, trzeba użyć następującej konfiguracji:
                         default_target_path: default_security_target
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -83,6 +85,7 @@ trasę ``default_security_target``, trzeba użyć następującej konfiguracji:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -113,6 +116,7 @@ opcji ``always_use_default_target_path`` na ``true``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -125,6 +129,7 @@ opcji ``always_use_default_target_path`` na ``true``:
                         always_use_default_target_path: true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -145,6 +150,7 @@ opcji ``always_use_default_target_path`` na ``true``:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -173,6 +179,7 @@ to ``false``):
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -186,6 +193,7 @@ to ``false``):
                         use_referer: true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -206,6 +214,7 @@ to ``false``):
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -233,6 +242,7 @@ kod:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# src/Acme/SecurityBundle/Resources/views/Security/login.html.twig #}
         {% if error %}
@@ -252,6 +262,7 @@ kod:
         </form>
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- src/Acme/SecurityBundle/Resources/views/Security/login.html.php -->
         <?php if ($error): ?>
@@ -278,6 +289,7 @@ opcję ``target_path_parameter`` na inną wartość.
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -290,6 +302,7 @@ opcję ``target_path_parameter`` na inną wartość.
                         target_path_parameter: redirect_url
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -310,6 +323,7 @@ opcję ``target_path_parameter`` na inną wartość.
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -337,6 +351,7 @@ Można ustawić to na inną trasę (np. ``login_failure``) w następujacy sposó
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -350,6 +365,7 @@ Można ustawić to na inną trasę (np. ``login_failure``) w następujacy sposó
                         failure_path: login_failure
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -370,6 +386,7 @@ Można ustawić to na inną trasę (np. ``login_failure``) w następujacy sposó
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(

--- a/cookbook/security/form_login_setup.rst
+++ b/cookbook/security/form_login_setup.rst
@@ -1,3 +1,6 @@
+.. highlight:: php
+   :linenothreshold: 2
+
 .. index::
    single: bezpieczeństwo; logowanie formularzowe
    single: bezpieczeństwo; formularz logowania
@@ -28,6 +31,7 @@ Najpierw, udostępnijmy logowanie formularzowe w zaporze:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -42,6 +46,7 @@ Najpierw, udostępnijmy logowanie formularzowe w zaporze:
                         check_path: /login_check
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -61,6 +66,7 @@ Najpierw, udostępnijmy logowanie formularzowe w zaporze:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -102,6 +108,7 @@ w kluczy ``form_login`` konfiguracji (``/login`` i ``/login_check``):
 .. configuration-block::
 
     .. code-block:: php-annotations
+       :linenos:
 
         // src/AppBundle/Controller/SecurityController.php
 
@@ -129,6 +136,7 @@ w kluczy ``form_login`` konfiguracji (``/login`` i ``/login_check``):
         }
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/routing.yml
         login_route:
@@ -141,6 +149,7 @@ w kluczy ``form_login`` konfiguracji (``/login`` i ``/login_check``):
             # as it's handled by the Security system
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/routing.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -159,6 +168,7 @@ w kluczy ``form_login`` konfiguracji (``/login`` i ``/login_check``):
         </routes>
 
     ..  code-block:: php
+        :linenos:
 
         // app/config/routing.php
         use Symfony\Component\Routing\RouteCollection;
@@ -220,6 +230,7 @@ Na koniec utwórzmy szablon:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/security/login.html.twig #}
         {# ... you will probably extends your base template, like base.html.twig #}
@@ -245,6 +256,7 @@ Na koniec utwórzmy szablon:
         </form>
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- src/Acme/SecurityBundle/Resources/views/Security/login.html.php -->
         <?php if ($error): ?>
@@ -351,6 +363,7 @@ pętlę przekierowań:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
 
@@ -359,6 +372,7 @@ pętlę przekierowań:
             - { path: ^/, roles: ROLE_ADMIN }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -375,6 +389,7 @@ pętlę przekierowań:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
 
@@ -389,6 +404,7 @@ uwierzytelniania, rozwiązuje problem:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
 
@@ -398,6 +414,7 @@ uwierzytelniania, rozwiązuje problem:
             - { path: ^/, roles: ROLE_ADMIN }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -415,6 +432,7 @@ uwierzytelniania, rozwiązuje problem:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
 
@@ -430,6 +448,7 @@ trzeba utworzyć specjalną zaporę umożliwiającą dostęp anonimowy do strony
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
 
@@ -444,6 +463,7 @@ trzeba utworzyć specjalną zaporę umożliwiającą dostęp anonimowy do strony
                 form_login: ~
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -466,6 +486,7 @@ trzeba utworzyć specjalną zaporę umożliwiającą dostęp anonimowy do strony
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
 

--- a/cookbook/security/impersonating_user.rst
+++ b/cookbook/security/impersonating_user.rst
@@ -1,3 +1,6 @@
+.. highlight:: php
+   :linenothreshold: 2
+
 .. index::
     single: bezpieczeństwo; podszywanie sie pod użytkownika
 
@@ -13,6 +16,7 @@ detektora (*ang. listener*) zapory ``switch_user``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -24,6 +28,7 @@ detektora (*ang. listener*) zapory ``switch_user``:
                     switch_user: true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -43,7 +48,8 @@ detektora (*ang. listener*) zapory ``switch_user``:
             </config>
         </srv:container>
 
-    .. code-block:: php
+    .. code-block:: php 
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -79,12 +85,14 @@ wyświetlania odnośnika do opuszczenia podszywania się:
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {% if is_granted('ROLE_PREVIOUS_ADMIN') %}
             <a href="{{ path('homepage', {'_switch_user': '_exit'}) }}">Exit impersonation</a>
         {% endif %}
 
     .. code-block:: html+php
+       :linenos:
 
         <?php if ($view['security']->isGranted('ROLE_PREVIOUS_ADMIN')): ?>
             <a
@@ -124,6 +132,7 @@ nazwę parametru zapytania  w ustawieniu ``parameter``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -135,6 +144,7 @@ nazwę parametru zapytania  w ustawieniu ``parameter``:
                     switch_user: { role: ROLE_ADMIN, parameter: _want_to_be_this_user }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="UTF-8"?>
@@ -154,6 +164,7 @@ nazwę parametru zapytania  w ustawieniu ``parameter``:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -186,6 +197,7 @@ Poniższy przykładowy kod pokazuje, jak można zmieniać lepkie ustawienia naro
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/services.yml
         services:
@@ -195,6 +207,7 @@ Poniższy przykładowy kod pokazuje, jak można zmieniać lepkie ustawienia naro
                     - { name: kernel.event_listener, event: security.switch_user, method: onSwitchUser }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/services.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -216,6 +229,7 @@ Poniższy przykładowy kod pokazuje, jak można zmieniać lepkie ustawienia naro
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/services.php
         $container
@@ -228,6 +242,7 @@ Poniższy przykładowy kod pokazuje, jak można zmieniać lepkie ustawienia naro
     Implementacja detektora zakłada, że encja ``User`` ma metodę ``getLocale()``.
 
 .. code-block:: php
+   :linenos:
 
         // src/AppBundle/EventListener/SwitchUserListener.pnp
         namespace AppBundle\EventListener;

--- a/cookbook/security/index.rst
+++ b/cookbook/security/index.rst
@@ -1,8 +1,8 @@
 Bezpieczeństwo
 ==============
 
-Uwierzytelnianie(identyfikacja i logowanie użytkownika)
--------------------------------------------------------
+Uwierzytelnianie (identyfikacja i logowanie użytkownika)
+--------------------------------------------------------
 
 .. toctree::
     :maxdepth: 2

--- a/cookbook/security/remember_me.rst
+++ b/cookbook/security/remember_me.rst
@@ -15,6 +15,7 @@ celu sekcję ``remember_me`` zapory:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -33,6 +34,7 @@ celu sekcję ``remember_me`` zapory:
                         #always_remember_me: true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <?xml version="1.0" encoding="utf-8" ?>
@@ -61,6 +63,7 @@ celu sekcję ``remember_me`` zapory:
         </srv:container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -147,6 +150,7 @@ będzie automatycznie logowany. Tak więc, formularz logowania może wyglądać 
 .. configuration-block::
 
     .. code-block:: html+jinja
+       :linenos:
 
         {# app/Resources/views/security/login.html.twig #}
         {% if error %}
@@ -167,6 +171,7 @@ będzie automatycznie logowany. Tak więc, formularz logowania może wyglądać 
         </form>
 
     .. code-block:: html+php
+       :linenos:
 
         <!-- app/Resources/views/security/login.html.php -->
         <?php if ($error): ?>
@@ -251,6 +256,7 @@ W poniższym przykładzie, akcja jest dozwolona, tylko jeśłi użytkownik ma ro
 ``IS_AUTHENTICATED_FULLY``.
 
 .. code-block:: php
+   :linenos:
 
     // ...
     use Symfony\Component\Security\Core\Exception\AccessDeniedException
@@ -267,6 +273,7 @@ Jeśłi aplikacja jest oparta na Symfony Standard Edition, można również zabe
 akcję za pomocą adnotacji:
 
 .. code-block:: php
+   :linenos:
 
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -149,6 +149,7 @@ Każdy pakiet może być dostosowywany poprzez pliki konfiguracyjne w języku YA
 XML, czy też PHP. Wystarczy popatrzeć na domyślną konfigurację Symfony:
 
 .. code-block:: yaml
+   :linenos:
 
     # app/config/config.yml
     imports:
@@ -196,6 +197,7 @@ odpowiedniego pliku konfiguracyjnego. Dla przykładu, środowisko ``dev`` wczytu
 modyfikuje go w celu dodania narzędzi do debugowania:
 
 .. code-block:: yaml
+   :linenos:
 
     # app/config/config_dev.yml
     imports:

--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -268,6 +268,7 @@ Dlatego szablon ``default/index.html.twig``, to to samo co
 temu kodowi:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {# app/Resources/views/default/index.html.twig #}
     {% extends 'base.html.twig' %}

--- a/quick_tour/the_controller.rst
+++ b/quick_tour/the_controller.rst
@@ -85,6 +85,7 @@ Utwórzmy nowy szablon ``app/Resources/views/default/hello.html.twig`` z następ
 zawartością:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {# app/Resources/views/default/hello.html.twig #}
     {% extends 'base.html.twig' %}
@@ -134,6 +135,7 @@ dla każdego obsługiwanego formatu wyjścia. W naszym przypadku trzeba utworzy�
 nowy szablon ``hello.xml.twig``:
 
 .. code-block:: xml+php
+   :linenos:
 
     <!-- app/Resources/views/default/hello.xml.twig -->
     <hello>
@@ -286,6 +288,7 @@ W szablonie, można także uzyskać dostęp do obiektu ``Request`` poprzez
 zmienną ``app.request``, automatycznie dostarczaną przez Symfony:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {{ app.request.query.get('page') }}
 
@@ -334,6 +337,7 @@ przed przekierowaniem użytkownika na inną stronę::
 Następnie mozna wyświetlić ten komunikat w szabloni, tak jak tu:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {% for flashMessage in app.session.flashbag.get('notice') %}
         <div class="flash-notice">

--- a/quick_tour/the_view.rst
+++ b/quick_tour/the_view.rst
@@ -101,6 +101,7 @@ Szablon ``index.html.twig`` używa znacznika ``extends`` do wskazania, że dzied
 ze wspólnego szblonu ``base.html.twig``:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {# app/Resources/views/default/index.html.twig #}
     {% extends 'base.html.twig' %}
@@ -113,6 +114,7 @@ Otwórz plik ``app/Resources/views/base.html.twig``, który odpowiada szablonowi
 ``base.html.twig`` i znajdź następujący kod Twig code:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {# app/Resources/views/base.html.twig #}
     <!DOCTYPE html>
@@ -166,6 +168,7 @@ Proszę sobie wyobrazić, że chcemy wyświetlić reklamy na niektórych stronac
 naszej aplikacji. Najpierw utwórzmy szablon ``banner.html.twig``:
 
 .. code-block:: jinja
+   :linenos:
 
     {# app/Resources/views/ads/banner.html.twig #}
     <div id="ad-banner">
@@ -176,6 +179,7 @@ Dla wyświetleniatej reklamy na stronie, dołączymy szablon ``banner.html.twig`
 używając funkcję ``include()``:
 
 .. code-block:: html+jinja
+   :linenos:
 
     {# app/Resources/views/default/index.html.twig #}
     {% extends 'base.html.twig' %}

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -11,6 +11,7 @@ Pełna domyślna konfiguracja
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         doctrine:
             dbal:
@@ -180,6 +181,7 @@ Pełna domyślna konfiguracja
                                 enabled:              false
 
     .. code-block:: xml
+       :linenos:
 
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
@@ -275,6 +277,7 @@ Poniższy przykład konfiguracji pokazuje wszystkie domyślne ustawienia konfigu
 rozpoznawane przez ORM:
 
 .. code-block:: yaml
+   :linenos:
    
     doctrine:
         orm:
@@ -301,6 +304,7 @@ lub ``service``.
 Poniższy przykład pokazuje ogólny zarys konfiguracji buforowania:
 
 .. code-block:: yaml
+   :linenos:
 
     doctrine:
         orm:
@@ -385,6 +389,7 @@ opcje konfiguracyjne:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         doctrine:
             dbal:
@@ -416,6 +421,7 @@ opcje konfiguracyjne:
                 keep_slave:           false
 
     .. code-block:: xml
+       :linenos:
 
         <?xml version="1.0" encoding="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
@@ -468,6 +474,7 @@ Jeżeli w pliku YAML chce się skonfigurować wiele połączeń, należy je umie
 kluczu ``connections`` i nadać im unikalna nazwę:
 
 .. code-block:: yaml
+   :linenos:
 
     doctrine:
         dbal:
@@ -502,6 +509,7 @@ Gdy używa się tylko jednego menadżera encji, wszystkie dostępne opcje konfig
 mozna umieścić bezpośrednio na poziomie ``doctrine.orm`` konfiguracji.
 
 .. code-block:: yaml
+   :linenos:
 
     doctrine:
         orm:
@@ -549,6 +557,7 @@ dla encji pakietu ``AppBundle`` w katalogu ``@AppBundle/SomeResources/config/doc
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         doctrine:
             # ...
@@ -562,6 +571,7 @@ dla encji pakietu ``AppBundle`` w katalogu ``@AppBundle/SomeResources/config/doc
                         dir: SomeResources/config/doctrine
 
     .. code-block:: xml
+       :linenos:
 
         <?xml version="1.0" charset="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
@@ -575,6 +585,7 @@ dla encji pakietu ``AppBundle`` w katalogu ``@AppBundle/SomeResources/config/doc
         </container>
 
     .. code-block:: php
+       :linenos:
 
         $container->loadFromExtension('doctrine', array(
             'orm' => array(
@@ -597,6 +608,7 @@ było odwoływać sie do takich rzeczy jak ``App:Post``):
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         doctrine:
                 # ...
@@ -612,6 +624,7 @@ było odwoływać sie do takich rzeczy jak ``App:Post``):
                             alias: App
 
     .. code-block:: xml
+       :linenos:
 
         <?xml version="1.0" charset="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
@@ -631,6 +644,7 @@ było odwoływać sie do takich rzeczy jak ``App:Post``):
         </container>
 
     .. code-block:: php
+       :linenos:
 
         $container->loadFromExtension('doctrine', array(
             'orm' => array(

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1,3 +1,6 @@
+.. highlight:: php
+   :linenothreshold: 2
+
 .. index::
    pair: konfiguracja; Framework
 
@@ -184,12 +187,14 @@ Szczegóły można znaleźć w :doc:`/cookbook/request/load_balancer_reverse_pro
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
             trusted_proxies:  [192.0.0.1, 10.0.0.0/8]
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -203,6 +208,7 @@ Szczegóły można znaleźć w :doc:`/cookbook/request/load_balancer_reverse_pro
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -236,12 +242,14 @@ jeśli uzywa się edytora PHPstorm na platformie Mac OS, trzeba zrobić coś tak
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
             ide: "phpstorm://open?file=%%f&line=%%l"
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -255,6 +263,7 @@ jeśli uzywa się edytora PHPstorm na platformie Mac OS, trzeba zrobić coś tak
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -329,12 +338,14 @@ odpowiedź 500.
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
             trusted_hosts:  ['example.com', 'example.org']
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -352,6 +363,7 @@ odpowiedź 500.
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -456,12 +468,14 @@ Ustawiajac tą opcje na ``true`` włącza sie obsługe ESI:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
             esi: true
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -477,6 +491,7 @@ Ustawiajac tą opcje na ``true`` włącza sie obsługe ESI:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -820,6 +835,7 @@ z pliku ``php.ini``:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -827,6 +843,7 @@ z pliku ``php.ini``:
                 save_path: ~
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -842,6 +859,7 @@ z pliku ``php.ini``:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -871,7 +889,7 @@ For example, suppose you have the following:
 .. configuration-block::
 
     .. code-block:: html+jinja
-
+       
         <img src="{{ asset('images/logo.png') }}" alt="Symfony!" />
 
     .. code-block:: php
@@ -884,6 +902,7 @@ Now, activate the ``assets_version`` option:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -891,6 +910,7 @@ Now, activate the ``assets_version`` option:
             templating: { engines: ['twig'], assets_version: v2 }
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -907,6 +927,7 @@ Now, activate the ``assets_version`` option:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -1005,6 +1026,7 @@ Assume you have custom global form themes in
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -1014,6 +1036,7 @@ Assume you have custom global form themes in
                         - 'WebsiteBundle:Form'
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1039,6 +1062,7 @@ Assume you have custom global form themes in
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -1075,6 +1099,7 @@ an asset's path:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -1088,6 +1113,7 @@ an asset's path:
                 #     http: "//cdn.example.com/"
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1106,6 +1132,7 @@ an asset's path:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -1132,6 +1159,7 @@ collection):
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -1143,6 +1171,7 @@ collection):
                 # assets_base_urls: "//cdn.example.com/"
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1159,6 +1188,7 @@ collection):
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -1215,6 +1245,7 @@ You can group assets into packages, to specify different base URLs for them:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/config.yml
         framework:
@@ -1225,6 +1256,7 @@ You can group assets into packages, to specify different base URLs for them:
                         base_urls: 'http://static_cdn.example.com/avatars'
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
@@ -1248,6 +1280,7 @@ You can group assets into packages, to specify different base URLs for them:
         </container>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/config.php
         $container->loadFromExtension('framework', array(
@@ -1513,6 +1546,7 @@ Pełna domyślna konfiguracja
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         framework:
             secret:               ~

--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -1,3 +1,6 @@
+.. highlight:: php
+   :linenothreshold: 2
+
 .. index::
     pair: konfiguracja; Kernel
 

--- a/reference/configuration/monolog.rst
+++ b/reference/configuration/monolog.rst
@@ -7,6 +7,7 @@ Konfiguracja pakietu Monolog
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         monolog:
             handlers:
@@ -18,18 +19,26 @@ Konfiguracja pakietu Monolog
                     level:               ERROR
                     bubble:              false
                     formatter:           my_formatter
-                    processors:
-                        - some_callable
                 main:
                     type:                fingers_crossed
                     action_level:        WARNING
                     buffer_size:         30
                     handler:             custom
+                console:
+                    type:                console
+                    verbosity_levels:
+                        VERBOSITY_NORMAL:       WARNING
+                        VERBOSITY_VERBOSE:      NOTICE
+                        VERBOSITY_VERY_VERBOSE: INFO
+                        VERBOSITY_DEBUG:        DEBUG
                 custom:
                     type:                service
                     id:                  my_handler
 
-                # Default options and values for some "my_custom_handler" 
+                # Default options and values for some "my_custom_handler"
+                # Note: many of these options are specific to the "type".
+                # For example, the "service" type doesn't use any options
+                # except id and channels
                 my_custom_handler:
                     type:                 ~ # Required
                     id:                   ~
@@ -56,9 +65,6 @@ Konfiguracja pakietu Monolog
                     email_prototype:
                         id:                   ~ # Required (when the email_prototype is used)
                         method:               ~
-                    channels:
-                        type:                 ~
-                        elements:             []
                     formatter:            ~
 
     .. code-block:: xml
@@ -66,8 +72,11 @@ Konfiguracja pakietu Monolog
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:monolog="http://symfony.com/schema/dic/monolog"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
-                                http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                http://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/monolog
+                http://symfony.com/schema/dic/monolog/monolog-1.0.xsd"
+        >
 
             <monolog:config>
                 <monolog:handler
@@ -83,6 +92,10 @@ Konfiguracja pakietu Monolog
                     type="fingers_crossed"
                     action-level="warning"
                     handler="custom"
+                />
+                <monolog:handler
+                    name="console"
+                    type="console"
                 />
                 <monolog:handler
                     name="custom"

--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -20,6 +20,7 @@ Każda część zostanie wyjaśniona w następnym rozdziale.
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -247,6 +248,10 @@ Każda część zostanie wyjaśniona w następnym rozdziale.
                 ROLE_SUPERADMIN: [ROLE_ADMIN]
 
 
+.. index::
+   single: bezpieczeństwo; konfiguracja logowania formularzowego
+   single: logowanie formularzowe; konfiguracja
+
 .. _reference-security-firewall-form-login:
 
 Konfiguracja logowania formularzowego
@@ -331,6 +336,11 @@ Przekierowanie po zalogowaniu
 * ``target_path_parameter`` (typ: ``string``, domyślnie: ``_target_path``)
 * ``use_referer`` (typ: ``Boolean``, domyślnie: ``false``)
 
+
+.. index::
+   single: bezpieczeństwo; koder PBKDF2
+   single: koder PBKDF2; konfiguracja
+
 .. _reference-security-pbkdf2:
 
 Stosowanie kodera PBKDF2: bezpieczeństwo i szybkość
@@ -347,6 +357,13 @@ i świadomie.
 
 Dobra konfiguracja wymaga użycia około 1000 iteracji i sha512 dla algorytmu mieszania.
 
+
+.. index::
+   single: bezpieczeństwo; koder BCrypt
+   single: koder BCrypt; konfiguracja
+
+.. _reference-security-pbkdf2:
+
 .. _reference-security-bcrypt:
 
 Stosowanie kodera BCrypt
@@ -360,7 +377,8 @@ Stosowanie kodera BCrypt
 .. configuration-block::
 
     .. code-block:: yaml
-
+       :linenos:
+       
         # app/config/security.yml
         security:
             # ...
@@ -371,6 +389,7 @@ Stosowanie kodera BCrypt
                     cost:      15
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <config>
@@ -383,6 +402,7 @@ Stosowanie kodera BCrypt
         </config>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -417,6 +437,10 @@ przechowywanie samego zakodowanego hasła.
     Wszystkie zakodowane hasła mają długość ``60`` znaków, więc należy zabezpieczyć
     dla nich dostateczną ilość miejsca.
 
+.. index::
+   single: bezpieczeństwo; zapory
+   single: zapora; konfiguracja
+
 .. _reference-security-firewall-context:
 
 Kontekst zapory
@@ -436,6 +460,7 @@ zapory, to "kontekst" będzie w rzeczywistości współdzielony:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -450,6 +475,7 @@ zapory, to "kontekst" będzie w rzeczywistości współdzielony:
                     context: my_context
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <security:config>
@@ -462,6 +488,7 @@ zapory, to "kontekst" będzie w rzeczywistości współdzielony:
         </security:config>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(
@@ -477,6 +504,10 @@ zapory, to "kontekst" będzie w rzeczywistości współdzielony:
             ),
         ));
 
+.. index::
+   HTTP-Digest
+   single: uwierzytelnianie; HTTP-Digest
+   single: bezpieczeństwo; uwierzytelnianie HTTP-Gigest
 
 Uwierzytelnianie HTTP-Digest
 ----------------------------
@@ -487,6 +518,7 @@ potrzeba dostarczyć dziedzinę (*ang. realm*)  i klucz:
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         # app/config/security.yml
         security:
@@ -497,6 +529,7 @@ potrzeba dostarczyć dziedzinę (*ang. realm*)  i klucz:
                         realm: "secure-api"
 
     .. code-block:: xml
+       :linenos:
 
         <!-- app/config/security.xml -->
         <security:config>
@@ -506,6 +539,7 @@ potrzeba dostarczyć dziedzinę (*ang. realm*)  i klucz:
         </security:config>
 
     .. code-block:: php
+       :linenos:
 
         // app/config/security.php
         $container->loadFromExtension('security', array(

--- a/reference/configuration/twig.rst
+++ b/reference/configuration/twig.rst
@@ -7,6 +7,7 @@ TwigBundle - Konfiguracja
 .. configuration-block::
 
     .. code-block:: yaml
+       :linenos:
 
         twig:
             exception_controller:  twig.controller.exception:showAction
@@ -53,6 +54,7 @@ TwigBundle - Konfiguracja
                 "%kernel.root_dir%/../vendor/acme/foo-bar/templates": foo_bar
 
     .. code-block:: xml
+       :linenos:
 
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -82,6 +84,7 @@ TwigBundle - Konfiguracja
         </container>
 
     .. code-block:: php
+       :linenos:
 
         $container->loadFromExtension('twig', array(
             'form_themes' => array(


### PR DESCRIPTION
Dodanie dyrektywy :linenos: do większych bloków code-block, co powodujerenderowanie w tekście numeracji linii kodu dla kompilacji dokumentacji
dokonywanej w Sphinx bez wtyczek Symfony (dotyczy to m.in. serwisu
readthedocs.org).