### PR TITLE
Poprawienie błędu składniowego sphinx.

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -709,7 +709,7 @@ czytaniu. Oznacza to też, że nasza przykładowa aplikacja może zawierać jesz
 mniej kodu. Dla przykładu przekształćmy szablon wykazu wpisów bloga na szablon
 napisany w Twigu:
 
-.. code-block:: html+twig
+.. code-block:: html+jinja
    :linenos:
 
     {# src/Acme/BlogBundle/Resources/views/Blog/list.html.twig #}
@@ -732,7 +732,7 @@ napisany w Twigu:
 
 Odpowiedni szablon ``layout.html.twig`` jest równie prosty:
 
-.. code-block:: html+twig
+.. code-block:: html+jinja
    :linenos:
 
     {# app/Resources/views/layout.html.twig #}

--- a/book/http_cache.rst
+++ b/book/http_cache.rst
@@ -1097,7 +1097,7 @@ stosuje standardowy helper ``render`` do skonfigurowania znaczników ESI:
 
 .. configuration-block::
 
-    .. code-block:: twig
+    .. code-block:: jinja
        :linenos:
 
         {# app/Resources/views/static/about.html.twig #}

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -387,7 +387,7 @@ tam plik ``number.html.twig`` z zawartością:
 
 .. configuration-block::
 
-    .. code-block:: twig
+    .. code-block:: jinja
        :linenos:
 
         {# app/Resources/views/lucky/number.html.twig #}

--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1607,7 +1607,7 @@ stosując pomocnicze funkcje szablonów:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         <a href="{{ path('blog_show', {'slug': 'my-blog-post'}) }}">
@@ -1650,7 +1650,7 @@ W PHP trzeba przekazać ``true`` do  ``generate()``:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         <a href="{{ url('blog_show', {'slug': 'my-blog-post'}) }}">

--- a/book/security.rst
+++ b/book/security.rst
@@ -974,7 +974,7 @@ rolę, trzeba użyć wbudowanej funkcji pomocniczej ``is_granted()``:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {% if is_granted('ROLE_ADMIN') %}
@@ -994,7 +994,7 @@ rolę, trzeba użyć wbudowanej funkcji pomocniczej ``is_granted()``:
     ``is_granted()`` na stronie, która nie znajdowała się za zaporą, powodując
     wyjątek. Dlatego potrzeba również sprawdzać najpierw istnienie użytkownika:
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         {% if app.user and is_granted('ROLE_ADMIN') %}
 
@@ -1174,7 +1174,7 @@ W szablonie Twig obiekt ten może być dostępny poprzez klucz :ref:`app.user <r
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {% if is_granted('IS_AUTHENTICATED_FULLY') %}

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -62,7 +62,7 @@ Pakiety Symfony są wyposażone w jeszcze bardziej silniejszy język szablonowan
 o nazwie `Twig`_. Twig pozwala pisać zwięzłe, czytelne szablony na kilka sposobów,
 które są bardziej przyjazne dla projektantów stron i są bardziej wydajne niż szablony PHP:
 
-.. code-block:: html+twig
+.. code-block:: html+jinja
    :linenos:
 
     <!DOCTYPE html>
@@ -96,7 +96,7 @@ Twig zawiera również **filtry**, które modyfikuja zawartość przed rozpoczę
 renderowania. Poniższe działanie powoduje zmianę znaków wartości zmiennej ``title``
 na duże litery, przed renderowaniem:
 
-.. code-block:: twig
+.. code-block:: jinja
 
     {{ title|upper }}
 
@@ -115,7 +115,7 @@ mogą być łatwo dodawane przez użytkownika. Na przyjkład, w poniższym kodzi
 użyto standardowy znacznik ``for`` i funkcję ``cycle`` do wydrukowania dziesięciu
 znaczników div, na przemian z klasami ``odd``, ``even``:
 
-.. code-block:: html+twig
+.. code-block:: html+jinja
    :linenos:
 
     {% for i in 0..10 %}
@@ -147,7 +147,7 @@ W tym rozdziale przykłady szablonów będą pokazywane zarówno jako szablony T
     przystępnym. Rozpatrzmy następujący przykład, który łączy pętlę z wyrażeniem
     logicznym ``if``:
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         <ul>
@@ -201,7 +201,7 @@ Po pierwsze, zbuduj podstawowy plik układu strony:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# app/Resources/views/base.html.twig #}
@@ -272,7 +272,7 @@ Szablon potomny może wyglądać tak:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# app/Resources/views/blog/index.html.twig #}
@@ -371,7 +371,7 @@ Oto kilka wskazówek o których trzeba pamietać przy pracy z dziedziczeniem sza
   użyć funkcji ``{{ parent() }}``. Jest to przydatne, gdy chce się dodać treść
   bloku nadrzędnego zamiast go całkowicie przesłonić:
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {% block sidebar %}
@@ -527,7 +527,7 @@ być wykorzystywany wielokrotnie.
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# src/AppBundle/Resources/views/Article/articleDetails.html.twig #}
@@ -553,7 +553,7 @@ Dołączanie tego szablonu do innego jest proste:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# src/AppBundle/Resources/views/Article/list.html.twig #}
@@ -641,7 +641,7 @@ Szablon ``recentList`` jest bardzo prosty:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# app/Resources/views/article/recent_list.html.twig #}
@@ -673,7 +673,7 @@ Dla dołączenia kontrolera, trzeba się do niego odwołać używając standardo
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# app/Resources/views/base.html.twig #}
@@ -722,7 +722,7 @@ do konfigurowania znaczników ``hinclude.js``:
 
 .. configuration-block::
 
-    .. code-block:: twig
+    .. code-block:: jinja
        :linenos:
 
         {{ render_hinclude(controller('...')) }}
@@ -840,7 +840,7 @@ wszystkie zdefiniowane globalne szablony):
 
 .. configuration-block::
 
-    .. code-block:: twig
+    .. code-block:: jinja
        :linenos:
 
         {{ render_hinclude(controller('...'),  {
@@ -862,7 +862,7 @@ albo można również określić łańcuch tekstowy do wyświetlenia jako domyś
 
 .. configuration-block::
 
-    .. code-block:: twig
+    .. code-block:: jinja
        
         {{ render_hinclude(controller('...'), {'default': 'Loading...'}) }}
 
@@ -960,7 +960,7 @@ do odpowiedniej trasy:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         <a href="{{ path('_welcome') }}">Home</a>
 
@@ -1037,7 +1037,7 @@ jak i wartość parametru ``{slug}``. Używając tej trasy, przeróbmy szablon
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# app/Resources/views/article/recent_list.html.twig #}
@@ -1065,14 +1065,14 @@ jak i wartość parametru ``{slug}``. Używając tej trasy, przeróbmy szablon
 
     Można również wygenerować bezwzględny adres URL stosując funkcję ``url``:
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         <a href="{{ url('_welcome') }}">Home</a>
 
     To samo można zrobić w szablonach PHP przez przekazanie do metody trzeciego
     argumentu ``generate()``:
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         <a href="{{ url('_welcome') }}">Home</a>
     
@@ -1107,7 +1107,7 @@ poprzez funkcję ``assets``:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         <img src="{{ asset('images/logo.png') }}" alt="Symfony!" />
 
@@ -1140,7 +1140,7 @@ Jeśli chce się ustawić wersję dla określonego aktywa, można ustawić czwar
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         <img src="{{ asset('images/logo.png', version='3.0') }}" alt="Symfony!" />
 
@@ -1163,7 +1163,7 @@ argument (lub argument ``absolute``) na ``true``:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         <img src="{{ absolute_url(asset('images/logo.png')) }}" alt="Symfony!" />
 
@@ -1214,7 +1214,7 @@ potrzebne w całej witrynie:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# app/Resources/views/base.html.twig #}
@@ -1263,7 +1263,7 @@ Wewnątrz szablonu strony kontaktowej trzeba zrobić co następuje:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         {# app/Resources/views/contact/contact.html.twig #}
@@ -1307,7 +1307,7 @@ symbolicznego.
 
 Wiersz linkujący w szablonie w naszym przykładzie teraz wyglądał będzie tak:
 
-.. code-block:: html+twig
+.. code-block:: html+jinja
 
    <link href="{{ asset('bundles/css/contact.css') }}" type="text/css" rel="stylesheet" />
 
@@ -1346,7 +1346,7 @@ dającej automatyczny dostęp do określonych zmiennych:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         <p>Username: {{ app.user.username }}</p>
@@ -1553,7 +1553,7 @@ Ta metoda działa doskonale z trzema różnymi typami szablonów, które właśn
   miałby szablon o nazwie ``AppBundle::layout.html.twig``, zawierający tylko
   elementy specyficzne dla blogu:
 
-  .. code-block:: html+twig
+  .. code-block:: html+jinja
      :linenos:
 
       {# app/Resources/views/blog/layout.html.twig #}
@@ -1569,7 +1569,7 @@ Ta metoda działa doskonale z trzema różnymi typami szablonów, które właśn
   Na przykład, strona "index" będzie wywoływana przez coś takiego, jak
   ``AppBundle:Blog:index.html.twig`` i zawierać będzie wykaz aktualnych wpisów blogu:
 
-  .. code-block:: html+twig
+  .. code-block:: html+jinja
      :linenos:
 
       {# app/Resources/views/blog/index.html.twig #}
@@ -1606,7 +1606,7 @@ przykład:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
 
         Hello {{ name }}
 
@@ -1658,7 +1658,7 @@ zawierają kod HTML. Domyślnie Twig będzie zabezpieczał ciało artykułu.
 
 Aby to normalnie przetworzyć (bez zamiany na encje), trzeba dodać filtr ``raw``:
 
-.. code-block:: twig
+.. code-block:: jinja
 
     {{ article.body|raw }}
 
@@ -1725,7 +1725,7 @@ na przykład wewnątrz kontrolera::
 
 Ten sam mechanizm może zostać uzyty w szablonach Twig dzięki funkcji ``dump``:
 
-.. code-block:: html+twig
+.. code-block:: html+jinja
    :linenos:
 
     {# app/Resources/views/article/recent_list.html.twig #}
@@ -1796,7 +1796,7 @@ z parametrem asocjacyjnym:
 
 .. configuration-block::
 
-    .. code-block:: html+twig
+    .. code-block:: html+jinja
        :linenos:
 
         <a href="{{ path('article_show', {'id': 123, '_format': 'pdf'}) }}">


### PR DESCRIPTION
W naszej dokumentacji (na razie) nie można stosować argumentu lexera
'twig' ani 'html+twig' czy 'php+twig'. Zamiast tego trzeba uzywać
argumenty 'jinja', 'html+jinja' i 'php+jinja', tak jak było to w
wersjach do 2.7.